### PR TITLE
FE-025 - Notification Toggle Visibility

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />

--- a/app/src/main/res/layout/activity_notification.xml
+++ b/app/src/main/res/layout/activity_notification.xml
@@ -69,7 +69,7 @@
         android:id="@+id/detection_alerts_header"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="10dp"
         android:text="@string/detection_notification_header"
         android:textStyle="bold"
         android:textColor="@color/navy_blue"
@@ -85,11 +85,13 @@
         android:layout_marginEnd="28dp"
         android:paddingVertical="8dp"
         android:text="@string/smishing_detection_notification_title"
-        android:textSize="20sp"
+        android:textSize="18sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/detection_alerts_header"
+        android:thumbTint="#3E5B73"
+        android:trackTint="#274B6B"
         tools:ignore="UseSwitchCompatOrMaterialXml" />
 
     <Switch
@@ -98,12 +100,14 @@
         android:layout_height="wrap_content"
         android:paddingVertical="8dp"
         android:text="@string/spam_detection_notification_title"
-        android:textSize="20sp"
+        android:textSize="18sp"
         android:layout_marginStart="28dp"
         android:layout_marginEnd="28dp"
         app:layout_constraintTop_toBottomOf="@+id/smishing_notification_switch"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        android:thumbTint="#3E5B73"
+        android:trackTint="#274B6B"
         tools:ignore="UseSwitchCompatOrMaterialXml" />
 
     <View
@@ -120,7 +124,7 @@
         android:id="@+id/push_notifications_header"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="10dp"
         android:text="@string/push_notification_header"
         android:textStyle="bold"
         android:textColor="@color/navy_blue"
@@ -136,12 +140,14 @@
         android:layout_height="wrap_content"
         android:paddingVertical="8dp"
         android:text="@string/news_notification_title"
-        android:textSize="20sp"
+        android:textSize="18sp"
         android:layout_marginStart="28dp"
         android:layout_marginEnd="28dp"
         app:layout_constraintTop_toBottomOf="@+id/push_notifications_header"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        android:thumbTint="#3E5B73"
+        android:trackTint="#274B6B"
         tools:ignore="UseSwitchCompatOrMaterialXml" />
 
     <Switch
@@ -153,11 +159,13 @@
         android:layout_marginEnd="28dp"
         android:paddingVertical="8dp"
         android:text="@string/incident_reports"
-        android:textSize="20sp"
+        android:textSize="18sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/news_notification_switch"
+        android:thumbTint="#3E5B73"
+        android:trackTint="#274B6B"
         tools:ignore="UseSwitchCompatOrMaterialXml" />
 
     <View
@@ -177,7 +185,7 @@
         android:id="@+id/system_maintenance_header"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="10dp"
         android:text="@string/system_maintenance_header"
         android:textColor="@color/navy_blue"
         android:textStyle="bold"
@@ -192,12 +200,14 @@
         android:layout_height="wrap_content"
         android:paddingVertical="8dp"
         android:text="@string/update_notifications"
-        android:textSize="20sp"
+        android:textSize="18sp"
         android:layout_marginStart="28dp"
         android:layout_marginEnd="28dp"
         app:layout_constraintTop_toBottomOf="@+id/system_maintenance_header"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        android:thumbTint="#3E5B73"
+        android:trackTint="#274B6B"
         tools:ignore="UseSwitchCompatOrMaterialXml" />
 
     <Switch
@@ -206,12 +216,14 @@
         android:layout_height="wrap_content"
         android:paddingVertical="8dp"
         android:text="@string/backup_reminder"
-        android:textSize="20sp"
+        android:textSize="18sp"
         android:layout_marginStart="28dp"
         android:layout_marginEnd="28dp"
         app:layout_constraintTop_toBottomOf="@+id/update_notification_switch"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        android:thumbTint="#3E5B73"
+        android:trackTint="#274B6B"
         tools:ignore="UseSwitchCompatOrMaterialXml" />
 
     <Switch
@@ -220,12 +232,14 @@
         android:layout_height="wrap_content"
         android:paddingVertical="8dp"
         android:text="@string/password_security_check"
-        android:textSize="20sp"
+        android:textSize="18sp"
         android:layout_marginStart="28dp"
         android:layout_marginEnd="28dp"
         app:layout_constraintTop_toBottomOf="@+id/backup_reminder_switch"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        android:thumbTint="#3E5B73"
+        android:trackTint="#274B6B"
         tools:ignore="UseSwitchCompatOrMaterialXml" />
 
     <View
@@ -242,14 +256,23 @@
         android:id="@+id/open_notification_settings_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/open_notification_settings"
-        android:textSize="20sp"
         android:layout_marginStart="28dp"
-        android:layout_marginEnd="28dp"
         android:layout_marginTop="16dp"
-        app:layout_constraintTop_toBottomOf="@+id/divider3"
+        android:layout_marginEnd="28dp"
+        android:backgroundTint="#FFFFFF"
+        android:text="Notification Settings"
+        android:textStyle="bold"
+        android:textSize="20sp"
+        android:elevation="8dp"
+        android:textColor="#274B6B"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/divider3"
+        app:rippleColor="#AFBABF"
+        app:strokeColor="#274B6B"
+        app:strokeWidth="3dp"
+        app:elevation="6dp"
+        tools:visibility="visible" />
 
 
 


### PR DESCRIPTION
Hey everyone,

I’ve made an improvement to the visibility of the switches and the notification button by implementing darker colors that align better with the logo. This change enhances the visibility and gives a more cohesive look to the app.

<img width="498" alt="Screenshot 2025-03-25 at 1 00 07 pm" src="https://github.com/user-attachments/assets/917b3da8-5a4a-4fd7-a73a-a0b13bb40ea0" />
