### PR TITLE
Fix feedback activity back button behavior; unified feedback launch  from Help

### DIFF
--- a/app/src/main/java/com/example/smishingdetectionapp/FeedbackActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/FeedbackActivity.java
@@ -1,6 +1,5 @@
 package com.example.smishingdetectionapp;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -23,8 +22,8 @@ public class FeedbackActivity extends AppCompatActivity {
         // Initialize the back button to go back to the previous screen
         ImageButton report_back = findViewById(R.id.feedback_back);
         report_back.setOnClickListener(v -> {
-                    startActivity(new Intent(this, SettingsActivity.class));
-                    finish();
+            // Instead of launching SettingsActivity, simply finish() to return to the previous screen
+            finish();
         });
 
         // Initialize input fields and submit button
@@ -63,7 +62,7 @@ public class FeedbackActivity extends AppCompatActivity {
             String feedback = feedbackInput.getText().toString();
             float rating = ratingBar.getRating();
 
-            // Simulating feedback submission (You can replace this with actual database or API code)
+            // Simulating feedback submission (Replace this with your actual database or API code)
             boolean isInserted = DatabaseAccess.sendFeedback(name, feedback, rating);
             if (isInserted) {
                 // Clear input fields after successful submission

--- a/app/src/main/java/com/example/smishingdetectionapp/HelpActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/HelpActivity.java
@@ -1,11 +1,9 @@
-
 package com.example.smishingdetectionapp;
 
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
-import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.RelativeLayout;
 import android.widget.Toast;
@@ -23,64 +21,61 @@ public class HelpActivity extends SharedActivity {
         super.onCreate(savedInstanceState);
         EdgeToEdge.enable(this);
         setContentView(R.layout.activity_help_updated);
+
+        // Apply window insets for Edge-to-Edge experience
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main), (v, insets) -> {
             Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
             return insets;
         });
-        //Back button to go back to settings dashboard
+
+        // Back button to go back to settings dashboard
         ImageButton report_back = findViewById(R.id.report_back);
         report_back.setOnClickListener(v -> {
             startActivity(new Intent(this, SettingsActivity.class));
             finish();
         });
 
-
-        // contact Us
+        // "Call Us" functionality
         RelativeLayout rv2 = findViewById(R.id.rv_2);
         rv2.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                // Handle the click event here
                 Intent phoneIntent = new Intent(Intent.ACTION_DIAL);
                 phoneIntent.setData(Uri.parse("tel:+1234567890")); // Replace with your phone number
                 startActivity(phoneIntent);
             }
         });
 
-        // Mail Us
+        // "Mail Us" functionality
         RelativeLayout rv1 = findViewById(R.id.rv_1);
         rv1.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                // Handle the click event here
                 Intent emailIntent = new Intent(Intent.ACTION_SENDTO);
                 emailIntent.setData(Uri.parse("mailto:support@example.com")); // Replace with your email
                 startActivity(emailIntent);
             }
         });
 
-        // FAQ
+        // FAQ functionality (already implemented elsewhere)
         RelativeLayout rv3 = findViewById(R.id.rv_3);
         rv3.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                // Handle the click event here
-                Toast.makeText(HelpActivity.this, "Faq", Toast.LENGTH_SHORT).show();
+                // For now, show a Toast (or launch FAQActivity if available)
+                Toast.makeText(HelpActivity.this, "FAQ screen not implemented yet", Toast.LENGTH_SHORT).show();
             }
         });
 
-        //Feedback
+        // Feedback functionality: Launch FeedbackActivity
         RelativeLayout rv4 = findViewById(R.id.rv_4);
         rv4.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                // Handle the click event here
-                Toast.makeText(HelpActivity.this, "Feedback", Toast.LENGTH_SHORT).show();
+                // Launch the FeedbackActivity that uses the feedback.xml layout
+                startActivity(new Intent(HelpActivity.this, FeedbackActivity.class));
             }
         });
-
-
-
     }
 }


### PR DESCRIPTION
Updated the FeedbackActivity to use finish() for the back button so that it returns to the previous screen. This ensures a unified feedback experience across the app when launched from both Settings and Help.

https://github.com/user-attachments/assets/5beee5a4-3708-4fda-85f9-f20fa3b48b39

