### PR TITLE
Signup page now has dark mode support

### DIFF
--- a/app/src/main/java/com/example/smishingdetectionapp/ui/Register/RegisterMain.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/ui/Register/RegisterMain.java
@@ -1,5 +1,8 @@
 package com.example.smishingdetectionapp.ui.Register;
 
+import android.content.res.Configuration;
+import androidx.core.content.ContextCompat;
+
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -86,6 +89,25 @@ public class RegisterMain extends AppCompatActivity {
                 validateAndCheckEmail(fullName, phoneNumber, email, password);
             }
         });
+
+        int nightModeFlags = getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+
+        if (nightModeFlags == Configuration.UI_MODE_NIGHT_YES) {
+            binding.getRoot().setBackgroundColor(ContextCompat.getColor(this, R.color.black));
+            binding.fullNameInput.setTextColor(ContextCompat.getColor(this, R.color.white));
+            binding.emailInput.setTextColor(ContextCompat.getColor(this, R.color.white));
+            binding.pnInput.setTextColor(ContextCompat.getColor(this, R.color.white));
+            binding.pwInput.setTextColor(ContextCompat.getColor(this, R.color.white));
+            binding.pw2Input.setTextColor(ContextCompat.getColor(this, R.color.white));
+        } else {
+            binding.getRoot().setBackgroundColor(ContextCompat.getColor(this, R.color.white));
+            binding.fullNameInput.setTextColor(ContextCompat.getColor(this, R.color.black));
+            binding.emailInput.setTextColor(ContextCompat.getColor(this, R.color.black));
+            binding.pnInput.setTextColor(ContextCompat.getColor(this, R.color.black));
+            binding.pwInput.setTextColor(ContextCompat.getColor(this, R.color.black));
+            binding.pw2Input.setTextColor(ContextCompat.getColor(this, R.color.black));
+        }
+
     }
 
     @Override


### PR DESCRIPTION
previously the page would not show readable text in dark mode as the text changed to match the white background. this fix ensures text is reasonable and updates when dark mode is enabled/disabled during signup process