### PR TITLE
FE-72 - Accessibility: Bold Text 🟢 

### DIFF
--- a/app/src/main/java/com/example/smishingdetectionapp/SharedActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/SharedActivity.java
@@ -7,6 +7,14 @@ import android.content.Intent;
 import androidx.appcompat.app.AppCompatActivity;
 import com.example.smishingdetectionapp.ui.login.LoginActivity;
 
+import android.content.SharedPreferences;
+import android.graphics.Typeface;
+import android.preference.PreferenceManager;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.Switch;
+import android.widget.TextView;
 
 public abstract class SharedActivity extends AppCompatActivity {
     private static final int SESSION_TIMEOUT_MS = 1200000; // Default 20 minute timer for session timeout // feel free to test with a shorter time to double check
@@ -18,8 +26,42 @@ public abstract class SharedActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        boolean isBold = prefs.getBoolean("bold_text_enabled", false);
+        setTheme(isBold ? R.style.Theme_SmishingDetectionApp_Bold : R.style.Theme_SmishingDetectionApp);
         super.onCreate(savedInstanceState);
         setupSessionTimeout();
+    }
+
+    @Override
+    public void setContentView(int layoutResID) {
+        super.setContentView(layoutResID);
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        if (prefs.getBoolean("bold_text_enabled", false)) {
+            View root = findViewById(android.R.id.content);
+            applyBoldToAllWidgets(root);
+        }
+    }
+    private void applyBoldToAllWidgets(View root) {
+        if (!(root instanceof ViewGroup)) return;
+
+        ViewGroup group = (ViewGroup) root;
+        for (int i = 0; i < group.getChildCount(); i++) {
+            View child = group.getChildAt(i);
+
+            if (child instanceof Switch || child instanceof androidx.appcompat.widget.SwitchCompat) {
+                ((TextView) child).setTypeface(null, Typeface.BOLD);
+            }
+
+            if (child instanceof Button || child instanceof com.google.android.material.button.MaterialButton) {
+                ((TextView) child).setTypeface(null, Typeface.BOLD);
+            }
+
+            if (child instanceof ViewGroup) {
+                applyBoldToAllWidgets(child);
+            }
+        }
     }
 
     private void setupSessionTimeout() {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -24,6 +24,7 @@
 
 
     <ScrollView
+        android:id="@+id/settingsScroll"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginBottom="16dp"
@@ -374,6 +375,20 @@
                 app:layout_constraintTop_toBottomOf="@+id/dark_modeBtn"
                 tools:ignore="UseSwitchCompatOrMaterialXml" />
 
+            <Switch
+                android:id="@+id/bold_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="28dp"
+                android:layout_marginEnd="28dp"
+                android:paddingVertical="8dp"
+                android:text="@string/bold_text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/always_underline_links"
+                tools:ignore="UseSwitchCompatOrMaterialXml" />
+
 
             <View
                 android:id="@+id/divider5"
@@ -383,7 +398,7 @@
                 app:layout_constraintEnd_toEndOf="@id/incident_report_switch"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="@id/spam_notification_switch"
-                app:layout_constraintTop_toBottomOf="@+id/always_underline_links" />
+                app:layout_constraintTop_toBottomOf="@+id/bold_text" />
 
 
             <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -331,6 +331,7 @@
     <!-- Miscellaneous -->
     <string name="buttons_rounded_alt">Rounded corner background used for buttons</string>
     <string name="menu_icon_alt">Hamburger menu icon in the top navigation bar</string>
+    <string name="bold_text">Bold Text</string>
 
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="BoldTextViewStyle" parent="Widget.AppCompat.TextView">
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="BoldTextAppearance" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textStyle">bold</item>
+    </style>
+    <style name="BoldButtonStyle" parent="Widget.AppCompat.Button">
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="BoldMaterialButtonStyle" parent="Widget.MaterialComponents.Button">
+        <item name="android:textStyle">bold</item>
+    </style>
+
+
+    <style name="BoldMaterialSwitch" parent="Widget.Material3.CompoundButton.MaterialSwitch">
+        <item name="android:textStyle">bold</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -14,7 +14,12 @@
         <!-- Customize your theme here. -->
     </style>
 
-   <style name="Theme.SmishingDetectionApp.NoActionBar">
+    <style name="Theme.SmishingDetectionApp" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/navy_blue</item>
+        <item name="colorSecondary">@color/baby_blue</item>
+    </style>
+
+    <style name="Theme.SmishingDetectionApp.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>
@@ -43,7 +48,16 @@
     </style>
 
 
-
+    <!--Text styling-->
+    <style name="Theme.SmishingDetectionApp.Bold">
+    <item name="android:textViewStyle">@style/BoldTextViewStyle</item>
+    <item name="textAppearanceBodyLarge">@style/BoldTextAppearance</item>
+    <item name="textAppearanceBodyMedium">@style/BoldTextAppearance</item>
+    <item name="textAppearanceBodySmall">@style/BoldTextAppearance</item>
+    <item name="android:buttonStyle">@style/BoldButtonStyle</item>
+    <item name="buttonStyle">@style/BoldMaterialButtonStyle</item>
+    <item name="materialSwitchStyle">@style/BoldMaterialSwitch</item>
+    </style>
 
 
 </resources>


### PR DESCRIPTION
NEW PR - POST LOCAL REPO FIX 
OLD PR WILL BE DELETED

I implemented a global Bold Text accessibility feature across the app to improve readability for users with low vision. I added a toggle in the Settings screen to enable or disable bold text, and ensured that the selected preference is applied consistently across all activities using the existing SharedActivity base class.

Modified: activity_settings.xml; themes.xml; SettingsActivity.java; SharedActivity.java; strings.xml

Created: styles.xml

The implementation uses the existing SharedActivity base class to apply the correct theme (Theme.SmishingDetectionApp.Bold or Theme.SmishingDetectionApp) before creating each activity. This ensures the selected preference is consistently applied app-wide without duplicating logic in every activity.

To address limitations in Material components, which often do not respect text style themes, a recursive utility method was added to SharedActivity to programmatically bold the text of all Switch, SwitchCompat, Button, and MaterialButton views after layout inflation. This guarantees that even non-theme-compliant widgets reflect the user's chosen preference.

Supporting styles were added to styles.xml, including BoldTextViewStyle and BoldTextAppearance, and a new theme (Theme.SmishingDetectionApp.Bold) was defined in themes.xml to apply these styles when bold mode is active. The toggle itself was added to activity_settings.xml, and SettingsActivity.java was updated to handle user preferences and preserve scroll position during theme changes.
![after](https://github.com/user-attachments/assets/d26ffafc-1148-41e8-809f-eeff1184a6b6)
![before](https://github.com/user-attachments/assets/81b3dd56-1665-4d6c-b8b0-d2cb71aaccd0)

https://github.com/user-attachments/assets/7dcaada4-6610-4f12-98a4-cb865745cf93