### PR TITLE
FE-052 Implement Image Alt Text Support 🟢 

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,7 +326,36 @@
     <string name="icon_information_alt">Black outline of a circle with a black i in the center</string>
     <string name="always_underline_links">Always underline links</string>
     <string name="report_svg_alt">Black flag outline</string>
-
+    <string name="baseline_archive_24_alt">Black solid box with a hollow arrow pointing down</string>
+    <string name="baseline_arrow_back_24_alt">Black arrow pointing to the left</string>
+    <string name="bot_message_background_alt">Plain light cream coloured square with rounded corners</string>
+    <string name="button_background_alt">Plain light blue coloured square with rounded corners</string>
+    <string name="card_rounded_alt">Plain light cream coloured square with rounded corners</string>
+    <string name="chat_assistant_svg_alt">White outline of a rectangular chat bubble with three white dots in a horizontal line in the center</string>
+    <string name="circle_background_alt">Plain light blue coloured circle</string>
+    <string name="close_button_alt">Black x</string>
+    <string name="counter_buttons_alt">Dark blue square with rounded corners that is transitioning colours to a light blue</string>
+    <string name="email_icon_alt">Black email icon</string>
+    <string name="emoji_background_alt">Plain white circle</string>
+    <string name="faq_icon_alt">Black question mark</string>
+    <string name="feedback_icon_alt">Solid black square chat bubble with an exclamation mark in the center</string>
+    <string name="hardhat_logo_notif_alt">Yellow shield with a dark blue outline with two oval rings crossing with a yellow construction hat above the sheild</string>
+    <string name="help_svg_alt">Black outline of a circle with a black question mark in the center</string>
+    <string name="ic_launcher_background_alt">Neon yellow with a white square grid</string>
+    <string name="ic_launcher_foreground_alt">Top half of a white robot head with two atennas</string>
+    <string name="icons8_home_48_alt">Black outline of a house</string>
+    <string name="icons8_house_48_alt">Black outline of a house with a solid black roof</string>
+    <string name="icons8_news_48_alt">Black outline of a piece of paper folded in half behind itself</string>
+    <string name="icons8_settings_48_alt">Black outline of a gear</string>
+    <string name="message_input_background_alt">Plain white square with rounded corners</string>
+    <string name="new_5_svg_alt">Black outline of a icosagon with the word new in the center positioned at a slight angle </string>
+    <string name="outline_bookmark_24_alt">Solid black bookmark icon</string>
+    <string name="phone_icon_alt">Solid black phone icon</string>
+    <string name="primary_button_alt">Neon green square</string>
+    <string name="send_button_background_alt">Solid dark blue circle</string>
+    <string name="send_icon_alt">White tringle pointing to the right with a thinner triangle shape removed from the center</string>
+    <string name="side_nav_bar_alt">Solid teal square</string>
+    <string name="user_message_background_alt">Solid dark blue square</string>
 
     <!-- Miscellaneous -->
     <string name="buttons_rounded_alt">Rounded corner background used for buttons</string>


### PR DESCRIPTION
If a user were using a screen reader to navigate the application, they would not be able to understand or take in information about what an image looks like. To increase accessibility, content descriptions should be added to each image throughout the application. This was tested by enabling text-to-speech output in Android settings.

For some of the images they are plain background colours for buttons. The content descriptions were not added for backgrounds for buttons due to the complexity or conflicting information that would be read out to the user.

[Alt text image dictionary .pdf](https://github.com/user-attachments/files/20114347/Alt.text.image.dictionary.pdf)
