### PR TITLE
FE-012 - News Section Navigation Highlight

### DIFF
--- a/app/src/main/res/layout/activity_news.xml
+++ b/app/src/main/res/layout/activity_news.xml
@@ -118,7 +118,6 @@
         app:itemBackground="@color/baby_blue"
         app:itemIconTint="@color/black"
         app:itemTextColor="@color/black"
-        app:itemActiveIndicatorStyle="@android:color/transparent"
         android:theme="@style/Theme.SmishingDetectionApp"
         app:menu="@menu/activity_main_drawer" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fix the navigation bar highlighting issue where Home and Settings sections have a pink highlight to indicate the current page, but the News section lacks this visual indicator.