### PR TITLE
Support Feedback Entry Relocates

### DIFF
--- a/app/src/main/java/com/example/smishingdetectionapp/chat/ChatAssistantActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/chat/ChatAssistantActivity.java
@@ -88,8 +88,12 @@ public class ChatAssistantActivity extends AppCompatActivity {
                 PopupMenu popup = new PopupMenu(ChatAssistantActivity.this, v);
                 popup.getMenuInflater().inflate(R.menu.chat_assistant_menu, popup.getMenu());
                 popup.setOnMenuItemClickListener(item -> {
-                    if (item.getItemId() == R.id.action_view_history) {
+                    int itemId = item.getItemId();
+                    if (itemId == R.id.action_view_history) {
                         startActivity(new Intent(ChatAssistantActivity.this, ChatHistoryActivity.class));
+                        return true;
+                    } else if (itemId == R.id.action_feedback) {
+                        openSupportFeedback();
                         return true;
                     }
                     return false;
@@ -292,5 +296,12 @@ public class ChatAssistantActivity extends AppCompatActivity {
                 imm.hideSoftInputFromWindow(getCurrentFocus().getWindowToken(), 0);
             }
         } catch (Exception ignored) { }
+    }
+
+    // ---------- Support Feedback ----------
+    private void openSupportFeedback() {
+        Intent intent = new Intent(this,
+                com.example.smishingdetectionapp.ui.SupportFeedbackActivity.class);
+        startActivity(intent);
     }
 }

--- a/app/src/main/res/menu/chat_assistant_menu.xml
+++ b/app/src/main/res/menu/chat_assistant_menu.xml
@@ -6,4 +6,10 @@
         android:title="@string/history"
         app:showAsAction="never" />
 
+    <!-- Support Feedback -->
+    <item
+        android:id="@+id/action_feedback"
+        android:title="@string/support_feedback_title"
+        app:showAsAction="never" />
+
 </menu>


### PR DESCRIPTION
This update relocates the Support Feedback entry to the chat interface (right-top menu) so users can report issues more conveniently during conversations. The history screen now only handles export and clear functions.
<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/aac1a177-14d9-421d-9955-62534089c8ce" />