### PR TITLE
fix(login): fix password visibility toggle not working

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />

--- a/app/src/main/java/com/example/smishingdetectionapp/ui/login/LoginActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/ui/login/LoginActivity.java
@@ -187,14 +187,18 @@ public class LoginActivity extends AppCompatActivity {
         });
 
         // Password visibility toggle
+        final boolean[] isPasswordVisible = {false};
         togglePasswordVisibility.setOnClickListener(v -> {
-            boolean isPasswordVisible = passwordEditText.getTransformationMethod() == null;
-            if (isPasswordVisible) {
+            if (isPasswordVisible[0]) {
+                // Hide password
                 passwordEditText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
-                togglePasswordVisibility.setImageResource(R.drawable.ic_passwords_visibility);
+                togglePasswordVisibility.setImageResource(android.R.drawable.ic_menu_view);
+                isPasswordVisible[0] = false;
             } else {
-                passwordEditText.setInputType(InputType.TYPE_CLASS_TEXT);
-                togglePasswordVisibility.setImageResource(R.drawable.ic_passwords_visibility);
+                // Show password
+                passwordEditText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
+                togglePasswordVisibility.setImageResource(android.R.drawable.ic_secure);
+                isPasswordVisible[0] = true;
             }
             passwordEditText.setSelection(passwordEditText.getText().length());
         });


### PR DESCRIPTION
## Description
The password visibility toggle button (eye icon) on the Login screen was did not function as intended.
Clicking the button did not toggle password visibility and the icon did not change state.

## Changes Made
- Fixed togglePasswordVisibility click listener in LoginActivity.java
- Used boolean flag to correctly track visibility state
- Password now correctly toggles between hidden and visible
- Icon now changes to reflect current state (but still uses placeholder icons)

## Testing
- Tested on Medium Phone API 36.1 emulator
- Password hides/shows correctly on button click
- Icon updates on each click

## Related Task
Microsoft Planner: Fix password visibility toggle on login screen