### PR TITLE
feat(auth): add forgot password screen and navigation

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -104,6 +104,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity> <!-- MainActivity is not the launcher anymore -->
+        <activity android:name=".ui.login.ForgotPasswordActivity"/>
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/example/smishingdetectionapp/ui/login/ForgotPasswordActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/ui/login/ForgotPasswordActivity.java
@@ -1,0 +1,21 @@
+package com.example.smishingdetectionapp.ui.login;
+
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.Toast;
+import androidx.appcompat.app.AppCompatActivity;
+import com.example.smishingdetectionapp.R;
+
+public class ForgotPasswordActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_forgot_password);
+
+        Button sendResetBtn = findViewById(R.id.sendResetLink);
+        sendResetBtn.setOnClickListener(v -> {
+            Toast.makeText(this, "Reset link sent to your email!", Toast.LENGTH_SHORT).show();
+        });
+    }
+}

--- a/app/src/main/java/com/example/smishingdetectionapp/ui/login/LoginActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/ui/login/LoginActivity.java
@@ -9,6 +9,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.ProgressBar;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
@@ -87,8 +88,8 @@ public class LoginActivity extends AppCompatActivity {
         final SignInButton googleBtn = binding.googleBtn;
         final Button registerButton = binding.registerButton;
         final ImageButton togglePasswordVisibility = binding.togglePasswordVisibility;
-        final Button togglePinLogin = binding.togglePinLogin;  // Added missing reference for togglePinLogin button
-
+        final Button togglePinLogin = binding.togglePinLogin;// Added missing reference for togglePinLogin button
+        final TextView forgotPasswordButton = binding.forgotPasswordButton;
         // Toggle functionality for PIN and Password login
         togglePinLogin.setOnClickListener(v -> {
             if (isPinLogin) {
@@ -127,6 +128,12 @@ public class LoginActivity extends AppCompatActivity {
                 }
                 loginWithPassword(email, input);
             }
+        });
+
+        // Handle forgot password click
+        forgotPasswordButton.setOnClickListener(v -> {
+            Intent intent = new Intent(LoginActivity.this, ForgotPasswordActivity.class);
+            startActivity(intent);
         });
 
         // Handle register button click

--- a/app/src/main/res/layout/activity_forgot_password.xml
+++ b/app/src/main/res/layout/activity_forgot_password.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:gravity="center">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Forgot Password"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="16dp"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Enter your email and we'll send you a reset link."
+        android:textSize="14sp"
+        android:gravity="center"
+        android:layout_marginBottom="24dp"/>
+
+    <EditText
+        android:id="@+id/forgotPasswordEmail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Enter your email"
+        android:inputType="textEmailAddress"
+        android:layout_marginBottom="16dp"/>
+
+    <Button
+        android:id="@+id/sendResetLink"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Send Reset Link"/>
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
The "Forgot Password" button on the Login screen was not navigating 
to any screen when tapped. This PR fixes the bug by creating a new 
Forgot Password screen and wiring up the navigation.

## Changes Made
- Created ForgotPasswordActivity.java
- Created activity_forgot_password.xml layout
- Added forgotPasswordButton binding in LoginActivity.java
- Wired up navigation from Login screen to Forgot Password screen
- Registered ForgotPasswordActivity in AndroidManifest.xml

## Testing
- Tested on Android emulator (Medium Phone API 36.1)
- Forgot Password button now navigates correctly to the new screen
- Send Reset Link button shows placeholder toast message

## Planner Task
[Fix Forgot Password Navigation - Microsoft Planner]