### PR TITLE
fix(settings): persist Always Underline Links toggle using SharedPref…

### DIFF
--- a/app/src/main/java/com/example/smishingdetectionapp/SettingsActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/SettingsActivity.java
@@ -45,12 +45,12 @@ import com.google.android.material.button.MaterialButton;
 public class SettingsActivity extends AppCompatActivity {
     private SeekBar seekBarFontScale;
     private TextView preview;
-    private static final int TIMEOUT_MILLIS = 10000; // 30 seconds timeout
+    private static final int TIMEOUT_MILLIS = 10000;
     private boolean isAuthenticated = false;
-    private BiometricPrompt biometricPrompt; // To cancel authentication
+    private BiometricPrompt biometricPrompt;
     private Button buttonIncreaseTextSize, buttonDecreaseTextSize, dialogCancel, dialogSignout;
     private TextView textScaleLabel;
-    private float textScale; // between 0.8f and 1.5f, for example
+    private float textScale;
     private Dialog dialog;
     private static final String KEY_SCROLL_POSITION = "scroll_position";
     private int savedPosition = 0;
@@ -81,33 +81,23 @@ public class SettingsActivity extends AppCompatActivity {
             AppCompatDelegate.setDefaultNightMode(
                     isChecked ? AppCompatDelegate.MODE_NIGHT_YES : AppCompatDelegate.MODE_NIGHT_NO
             );
-
             prefs.edit().putBoolean("dark_mode", isChecked).apply();
-
-            // Optional: recreate activity to apply theme changes immediately
             recreate();
         });
-
 
         textScaleLabel = findViewById(R.id.textScaleLabel);
         seekBarFontScale = findViewById(R.id.seekBarFontScale);
         textScale = PreferencesUtil.getTextScale(this);
         updateScaleLabel();
 
-
-
-// Set current SeekBar position
         seekBarFontScale.setProgress((int) (textScale * 10));
 
         seekBarFontScale.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
                 float newScale = progress / 10f;
-
-                // Clamp between 0.8f and 1.5f
                 if (newScale < 0.8f) newScale = 0.8f;
                 if (newScale > 1.5f) newScale = 1.5f;
-
                 textScale = newScale;
                 PreferencesUtil.setTextScale(SettingsActivity.this, textScale);
                 updateScaleLabel();
@@ -115,12 +105,10 @@ public class SettingsActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onStartTrackingTouch(SeekBar seekBar) {
-            }
+            public void onStartTrackingTouch(SeekBar seekBar) {}
 
             @Override
-            public void onStopTrackingTouch(SeekBar seekBar) {
-            }
+            public void onStopTrackingTouch(SeekBar seekBar) {}
         });
 
         if (isBold) {
@@ -132,17 +120,17 @@ public class SettingsActivity extends AppCompatActivity {
 
         scrollView = findViewById(R.id.settingsScroll);
 
-        //Cold start/ navigation icon
         boolean isFromNav = getIntent().getBooleanExtra("from_navigation", false);
         boolean isCold = prefs.getBoolean("cold_start", true);
 
         if (isFromNav || isCold) {
             scrollView.post(() -> scrollView.scrollTo(0, 0));
-            prefs.edit().putBoolean("cold_start", false).apply();  // 冷启动处理完毕
+            prefs.edit().putBoolean("cold_start", false).apply();
         } else {
             restoreScrollPosition();
         }
 
+        // Bold Text switch
         Switch boldSwitch = findViewById(R.id.bold_text);
         if (boldSwitch != null) {
             boldSwitch.setChecked(isBold);
@@ -153,20 +141,30 @@ public class SettingsActivity extends AppCompatActivity {
             });
         }
 
-        BottomNavCoordinator.setup(this, R.id.nav_settings);
+        // Always Underline Links switch
+        Switch underlineSwitch = findViewById(R.id.always_underline_links);
+        if (underlineSwitch != null) {
+            boolean isUnderline = prefs.getBoolean("always_underline_links", false);
+            underlineSwitch.setChecked(isUnderline);
+            underlineSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                saveScrollPosition();
+                prefs.edit().putBoolean("always_underline_links", isChecked).apply();
+            });
+        }
 
+        BottomNavCoordinator.setup(this, R.id.nav_settings);
 
         // Account button to switch to account page with biometric authentication
         Button accountBtn = findViewById(R.id.accountBtn);
         accountBtn.setOnClickListener(v -> triggerBiometricAuthenticationWithTimeout());
 
-        //Notification button to switch to notification page
+        // Notification button to switch to notification page
         Button notificationBtn = findViewById(R.id.notificationBtn);
         notificationBtn.setOnClickListener(v -> {
             startActivity(new Intent(this, NotificationActivity.class));
         });
 
-        //Filtering button to switch to Smishing rules page
+        // Filtering button to switch to Smishing rules page
         ImageView filteringBtn = findViewById(R.id.imageView7);
         if (filteringBtn != null) {
             filteringBtn.setOnClickListener(v -> {
@@ -179,7 +177,6 @@ public class SettingsActivity extends AppCompatActivity {
         reportBtn.setOnClickListener(v -> {
             startActivity(new Intent(this, CommunityReportActivity.class));
         });
-
 
         // Help button to switch to Help page
         Button helpBtn = findViewById(R.id.helpBtn);
@@ -194,7 +191,6 @@ public class SettingsActivity extends AppCompatActivity {
             startActivity(intent);
         });
 
-
         Button aboutUsBtn = findViewById(R.id.aboutUsBtn);
         aboutUsBtn.setOnClickListener(v -> {
             Intent intent = new Intent(SettingsActivity.this, AboutUsActivity.class);
@@ -207,21 +203,19 @@ public class SettingsActivity extends AppCompatActivity {
             startActivity(intent);
         });
 
-
-
         Button chatAssistantBtn = findViewById(R.id.chatAssistantBtn);
         chatAssistantBtn.setOnClickListener(v -> {
             Intent intent = new Intent(SettingsActivity.this, ChatAssistantActivity.class);
             startActivity(intent);
         });
 
-        //Feedback Button to switch to Feedback page
+        // Feedback Button to switch to Feedback page
         Button feedbackBtn = findViewById(R.id.feedbackBtn);
         feedbackBtn.setOnClickListener(v -> {
             startActivity(new Intent(this, FeedbackActivity.class));
         });
 
-        //Community Button to switch to Community page
+        // Community Button to switch to Community page
         Button communityBtn = findViewById(R.id.communityBtn);
         communityBtn.setOnClickListener(v -> {
             Intent i = new Intent(this, CommunityHomeActivity.class);
@@ -237,41 +231,33 @@ public class SettingsActivity extends AppCompatActivity {
         dialogCancel = dialog.findViewById(R.id.signoutCancelBtn);
         dialogSignout = dialog.findViewById(R.id.signoutBtn);
 
-        dialogCancel.setOnClickListener(v -> {
-            dialog.dismiss();
-        });
+        dialogCancel.setOnClickListener(v -> dialog.dismiss());
+
         dialogSignout.setOnClickListener(v -> {
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
             startActivity(intent);
             finish();
         });
 
-        signoutBtn.setOnClickListener(v -> {
-            dialog.show();
-        });
+        signoutBtn.setOnClickListener(v -> dialog.show());
+
         if (isTaskRoot()) {
             prefs.edit().putBoolean("cold_start", true).apply();
             prefs.edit().remove("scroll_pos").apply();
         }
+
         MaterialButton inviteFriendsBtn = findViewById(R.id.inviteFriendsBtn);
         inviteFriendsBtn.setOnClickListener(v -> {
             String playLink = "https://play.google.com/store/apps/details?id=" + getPackageName();
             String msg = "Stay safe from smishing! Try the Smishing Detection app:\n" + playLink;
-
             Intent share = new Intent(Intent.ACTION_SEND);
             share.setType("text/plain");
             share.putExtra(Intent.EXTRA_SUBJECT, "Join me on Smishing Detection");
             share.putExtra(Intent.EXTRA_TEXT, msg);
-
             startActivity(Intent.createChooser(share, "Invite a Friend"));
         });
-
-
-
-
     }
 
-    // Trigger biometric authentication with timeout
     private void triggerBiometricAuthenticationWithTimeout() {
         int authenticators = BiometricManager.Authenticators.BIOMETRIC_STRONG
                 | BiometricManager.Authenticators.DEVICE_CREDENTIAL;
@@ -279,19 +265,14 @@ public class SettingsActivity extends AppCompatActivity {
         BiometricManager bm = BiometricManager.from(this);
         switch (bm.canAuthenticate(authenticators)) {
             case BiometricManager.BIOMETRIC_SUCCESS:
-                // safe to ask for biometrics / device PIN
                 biometricPrompt = getPrompt();
                 biometricPrompt.authenticate(buildPromptInfo(authenticators));
                 startTimeoutTimer();
                 break;
-
             case BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED:
-                // nothing enrolled → just open the Account screen (or send user to settings)
                 openAccountActivity();
                 break;
-
             default:
-                // sensor missing, locked out, etc. → fall back or notify
                 notifyUser("Biometric authentication unavailable");
                 openAccountActivity();
                 break;
@@ -306,7 +287,6 @@ public class SettingsActivity extends AppCompatActivity {
                 .build();
     }
 
-    // BiometricPrompt setup
     private BiometricPrompt getPrompt() {
         Executor executor = ContextCompat.getMainExecutor(this);
         BiometricPrompt.AuthenticationCallback callback = new BiometricPrompt.AuthenticationCallback() {
@@ -321,8 +301,8 @@ public class SettingsActivity extends AppCompatActivity {
             public void onAuthenticationSucceeded(@NonNull BiometricPrompt.AuthenticationResult result) {
                 super.onAuthenticationSucceeded(result);
                 notifyUser("Authentication Succeeded!");
-                isAuthenticated = true; // Mark as authenticated
-                openAccountActivity(); // Proceed to AccountActivity
+                isAuthenticated = true;
+                openAccountActivity();
             }
 
             @Override
@@ -331,41 +311,35 @@ public class SettingsActivity extends AppCompatActivity {
                 notifyUser("Authentication Failed");
             }
         };
-
         return new BiometricPrompt(this, executor, callback);
     }
 
-    // Start a timeout timer for authentication
     private void startTimeoutTimer() {
         new Handler().postDelayed(() -> {
-            if (!isAuthenticated) { // If authentication hasn't occurred within the timeout
+            if (!isAuthenticated) {
                 notifyUser("Authentication timed out. Redirecting to Settings...");
-                biometricPrompt.cancelAuthentication(); // Cancel the ongoing authentication
-                redirectToSettingsActivity(); // Redirect to SettingsActivity on timeout
+                biometricPrompt.cancelAuthentication();
+                redirectToSettingsActivity();
             }
         }, TIMEOUT_MILLIS);
     }
 
-    // Redirect to SettingsActivity
     private void redirectToSettingsActivity() {
         Intent intent = new Intent(SettingsActivity.this, SettingsActivity.class);
         startActivity(intent);
-        finish(); // Ensure the current activity is closed
+        finish();
     }
 
-    // Open AccountActivity
     private void openAccountActivity() {
         Intent intent = new Intent(SettingsActivity.this, AccountActivity.class);
         startActivity(intent);
-        finish(); // Close SettingsActivity if AccountActivity is opened
+        finish();
     }
 
-    // Show a toast message
     private void notifyUser(String message) {
         Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
     }
 
-    // Notification button to switch to notification page
     public void openNotificationsActivity(View view) {
         Intent intent = new Intent(this, NotificationActivity.class);
         startActivity(intent);
@@ -373,50 +347,37 @@ public class SettingsActivity extends AppCompatActivity {
 
     private void applyBoldToAllSwitches(View root) {
         if (!(root instanceof ViewGroup)) return;
-
         ViewGroup group = (ViewGroup) root;
         for (int i = 0; i < group.getChildCount(); i++) {
             View child = group.getChildAt(i);
-
             if (child instanceof android.widget.Switch || child instanceof androidx.appcompat.widget.SwitchCompat) {
                 ((TextView) child).setTypeface(null, Typeface.BOLD);
             }
-
             applyBoldToAllSwitches(child);
         }
     }
 
     private void applyBoldToAllWidgets(View root) {
         if (!(root instanceof ViewGroup)) return;
-
         ViewGroup group = (ViewGroup) root;
         for (int i = 0; i < group.getChildCount(); i++) {
             View child = group.getChildAt(i);
-
-            // ✅ Bold Switch labels
             if (child instanceof android.widget.Switch || child instanceof androidx.appcompat.widget.SwitchCompat) {
                 ((TextView) child).setTypeface(null, Typeface.BOLD);
             }
-
-            // ✅ Bold Buttons (MaterialButton, Button, etc.)
             if (child instanceof android.widget.Button ||
                     child instanceof com.google.android.material.button.MaterialButton) {
                 ((TextView) child).setTypeface(null, Typeface.BOLD);
             }
-
-            // Recursively apply to nested children
             applyBoldToAllWidgets(child);
         }
     }
 
     private void applyFontScale() {
         Configuration configuration = getResources().getConfiguration();
-        configuration = new Configuration(configuration); // make a copy
+        configuration = new Configuration(configuration);
         configuration.fontScale = textScale;
-
         getResources().updateConfiguration(configuration, getResources().getDisplayMetrics());
-
-        // Refresh the layout
         recreate();
     }
 
@@ -451,14 +412,10 @@ public class SettingsActivity extends AppCompatActivity {
 
     private void restoreScrollPosition() {
         savedPosition = prefs.getInt("scroll_pos", 0);
-
         if (isTaskRoot()) {
             savedPosition = 0;
         }
-
-        scrollView.post(() ->
-                scrollView.scrollTo(0, savedPosition)
-        );
+        scrollView.post(() -> scrollView.scrollTo(0, savedPosition));
     }
 
     @Override
@@ -475,4 +432,3 @@ public class SettingsActivity extends AppCompatActivity {
         }
     }
 }
-


### PR DESCRIPTION
Summary
Fixes the Always Underline Links toggle in Settings > Accessibility 
not persisting when navigating away and returning.

 Problem
The always_underline_links switch had no SharedPreferences 
implementation — it existed in the XML layout but was completely 
unhandled in SettingsActivity.java, causing it to reset every time.

 Solution
Added SharedPreferences save and load logic for the 
always_underline_links switch, consistent with how other 
accessibility switches like bold_text are handled.

 Testing
Tested manually on physical device - toggle now persists 
correctly after navigating away and returning to Settings.

 Microsoft Planner Task
Fix Always Underline Links setting not persisting in Accessibility