### PR TITLE
fix(ui): remove invisible debug button intercepting touches on main screen

### DIFF
--- a/app/src/main/java/com/example/smishingdetectionapp/MainActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/MainActivity.java
@@ -52,12 +52,6 @@ public class MainActivity extends SharedActivity {
 
         BottomNavCoordinator.setup(this, R.id.nav_home);
 
-        Button debugBtn = findViewById(R.id.debug_btn);
-        if (debugBtn != null) {
-            debugBtn.setOnClickListener(v ->
-                    startActivity(new Intent(MainActivity.this, DebugActivity.class))
-            );
-        }
 
         // ===== CLICK TARGETS FOR "VIEW DETECTIONS" AND "RISK SCANNER" =====
         // Prefer the new card containers if present; otherwise fall back to legacy buttons.
@@ -119,8 +113,8 @@ public class MainActivity extends SharedActivity {
 
         // TapTarget guide
         boolean showGuideNow = getIntent().getBooleanExtra("showGuide", false);
-        if (showGuideNow && debugBtn != null) {
-            debugBtn.post(() -> {
+        if (showGuideNow) {
+            new Handler(Looper.getMainLooper()).post(() -> {
                 View ttNew   = findViewById(R.id.new_detections_container);
                 View ttTotal = findViewById(R.id.total_detections_container);
                 View ttView  = (findViewById(R.id.view_detections_container) != null)

--- a/app/src/main/res/layout-large/activity_main.xml
+++ b/app/src/main/res/layout-large/activity_main.xml
@@ -217,26 +217,6 @@
             android:contentDescription="@string/hardhat_logo_alt"
             app:layout_constraintTop_toBottomOf="@+id/HardhatLogo" />
 
-        <Button
-            android:id="@+id/debug_btn"
-            android:layout_width="113dp"
-            android:layout_height="111dp"
-            android:layout_marginStart="149dp"
-            android:layout_marginTop="8dp"
-
-
-            android:layout_marginEnd="150dp"
-            android:alpha="0"
-            android:autoText="true"
-
-            android:text="Button"
-            app:layout_constraintBottom_toBottomOf="@+id/HardhatLogo"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.0"
-            tools:ignore="MissingConstraints" />
 
         <Button
             android:id="@+id/fragment_container"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -49,24 +49,6 @@
             android:layout_height="wrap_content"
             android:paddingBottom="24dp">
 
-            <!-- Debug Button (hidden) -->
-            <Button
-                android:id="@+id/debug_btn"
-                android:layout_width="113dp"
-                android:layout_height="111dp"
-                android:layout_marginStart="149dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="150dp"
-                android:alpha="0"
-                android:autoText="true"
-                android:text="Button"
-                tools:ignore="MissingConstraints"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="@+id/HardhatLogo"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintVertical_bias="0.0" />
 
             <!-- Logo -->
             <ImageView


### PR DESCRIPTION
## Summary

- Removes a 113×111dp `Button` (`debug_btn`) that was set to `android:alpha="0"`, making it invisible but still present in the layout and still capturing touch events
- The button was positioned over the top-left of the main screen (overlapping the HardhatLogo area) and silently navigated users to `DebugActivity` on accidental tap
- Removed from both `layout/activity_main.xml` and `layout-large/activity_main.xml` (tablet variant)
- Removed the corresponding `debugBtn.setOnClickListener()` block from `MainActivity.java`
- The TapTarget walkthrough guide that previously used `debugBtn.post()` as its deferred-execution hook has been updated to use `new Handler(Looper.getMainLooper()).post()` instead — same behaviour, no dependency on the removed view

## Root cause

`debug_btn` was introduced in commit `511d709` (April 2024) as a developer shortcut to `DebugActivity`. It was never removed after development, and `android:alpha="0"` was used to hide it visually while leaving it fully interactive.

## Files changed

| File | Change |
|------|--------|
| `app/src/main/res/layout/activity_main.xml` | Removed `debug_btn` Button block |
| `app/src/main/res/layout-large/activity_main.xml` | Removed `debug_btn` Button block (tablet layout) |
| `app/src/main/java/.../MainActivity.java` | Removed click listener; replaced `debugBtn.post()` with `Handler(Looper.getMainLooper()).post()` |

## Test plan

- [ ] Launch the app on a phone-sized emulator — confirm the main screen loads normally with no visual change
- [ ] Launch the app on a tablet/large-screen emulator — confirm the same
- [ ] Tap around the top-left area of the main screen (where the button previously lived) — confirm no accidental navigation to `DebugActivity`
- [ ] Trigger the onboarding guide (`showGuide=true` intent extra) — confirm the TapTarget walkthrough still runs correctly through all steps
