### PR TITLE
fix(education): standardise button colour on Learn More About Smishin…

### DIFF
--- a/app/src/main/res/layout/activity_education.xml
+++ b/app/src/main/res/layout/activity_education.xml
@@ -95,7 +95,6 @@
                     android:padding="8dp"/>
             </androidx.cardview.widget.CardView>
 
-
             <!-- Quiz Section -->
             <TextView
                 android:id="@+id/QuteQuize"
@@ -135,8 +134,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Get Started"
-                android:textColor="#567BDB"
-                android:backgroundTint="#1A5477D1"
+                android:textColor="@android:color/white"
+                android:backgroundTint="#567BDB"
                 app:cornerRadius="24dp"
                 android:paddingHorizontal="24dp"
                 android:paddingVertical="12dp"


### PR DESCRIPTION
Summary
Fixes inconsistent button colour on the Education screen 
under the Learn More About Smishing section.

 Problem
The "Get Started" button had a transparent background with 
blue text, while the "Take the Quiz" and "Case Studies" 
buttons both had a solid blue background with white text. 
This created a visual inconsistency on the same screen.

Solution
Updated the tutorialBtn in activity_education.xml to use 
the same backgroundTint (#567BDB) and white text colour 
as the other two buttons.

Testing
Tested manually on physical device - all three buttons 
now have a consistent solid blue appearance.

Microsoft Planner Task
Fix inconsistent button colour on Learn More About Smishing screen