### PR TITLE
fix(accessibility): improve contentDescription strings to be functional rather than visual

### DIFF
--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -634,6 +634,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginEnd="4dp"
+                android:contentDescription="@string/help_svg_alt"
                 app:layout_constraintEnd_toEndOf="@+id/helpBtn"
                 app:layout_constraintTop_toTopOf="@+id/helpBtn"
                 app:srcCompat="@drawable/help_svg" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -415,15 +415,15 @@
     <string name="MoreInfoandSupport">More Info and Support</string>
 
     <!-- Accessibility Alt Texts -->
-    <string name="account_user_svg_alt">Black outline of a persons head and body</string>
+    <string name="account_user_svg_alt">Account details</string>
     <string name="back_button_alt">Black circle outline with a black arrow pointing to the left</string>
     <string name="background_gradient_alt">Black outline of a square</string>
     <string name="baseline_access_time_24_alt">Black circle with two lines representing the time 12:20</string>
     <string name="bell_svg_alt">Black outline of a bell</string>
-    <string name="filter_svg_alt">Black outline of a filter where the top is slightly ajar</string>
+    <string name="filter_svg_alt">Filter options</string>
     <string name="hardhat_logo_alt">Yellow shield with a dark blue outline with two oval rings crossing with a yellow construction hat above the shield</string>
     <string name="notification_svg1_alt">Black outline of a bell</string>
-    <string name="outline_arrow_outward_24_alt">Black arrow pointing towards the top right</string>
+    <string name="outline_arrow_outward_24_alt">Navigate to section</string>
     <string name="outline_archive_24_alt">Black outline of a box with a solid black arrow pointing down</string>
     <string name="icon_information_alt">Black outline of a circle with a black i in the center</string>
     <string name="always_underline_links">Always underline links</string>
@@ -442,7 +442,7 @@
     <string name="faq_icon_alt">Black question mark</string>
     <string name="feedback_icon_alt">Solid black square chat bubble with an exclamation mark in the center</string>
     <string name="hardhat_logo_notif_alt">Yellow shield with a dark blue outline with two oval rings crossing with a yellow construction hat above the sheild</string>
-    <string name="help_svg_alt">Black outline of a circle with a black question mark in the center</string>
+    <string name="help_svg_alt">Help and support</string>
     <string name="ic_launcher_background_alt">Neon yellow with a white square grid</string>
     <string name="ic_launcher_foreground_alt">Top half of a white robot head with two atennas</string>
     <string name="icons8_home_48_alt">Black outline of a house</string>


### PR DESCRIPTION
 ## Summary
            
  - Added missing `android:contentDescription` attribute to `imageView8` (help icon) in `activity_settings.xml`
  - Updated 4 `contentDescription` strings in `strings.xml` from visual/appearance-based descriptions to functional descriptions that better communicate purpose to screen reader users:                                                                                                                                                                                
    - `help_svg_alt`: "Black outline of a circle..." → "Help and support"                                                                                                               
    - `account_user_svg_alt`: "Black outline of a persons head and body" → "Account details"                                                                                                                                                                                                                                                                            
    - `outline_arrow_outward_24_alt`: "Black arrow pointing towards the top right" → "Navigate to section"                                                                                                                                                                                                                                                              
    - `filter_svg_alt`: "Black outline of a filter where the top is slightly ajar" → "Filter options"     
                                                                                                                                                                                                                                                                                                                                                                        
  ## Test plan                                              
                                                                                                                                                                                                                                                                                                                                                                        
  - [ ] Enable TalkBack on an Android device or emulator    
  - [ ] Navigate to the Settings screen and verify all icons are announced with meaningful descriptions                                                                                                                                                                                                                                                                 
  - [ ] Confirm the help icon (`imageView8`) is now announced as "Help and support"                    
  - [ ] Confirm navigation arrow icons are announced as "Navigate to section"                                                                                                                                                                                                                                                                                           
  - [ ] Confirm the filter icon is announced as "Filter options"             
  - [ ] Confirm the account icon is announced as "Account details" 