### PR TITLE
feat(community): show active filter label on posts screen

### DIFF
--- a/app/src/main/java/com/example/smishingdetectionapp/Community/CommunityPostActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/Community/CommunityPostActivity.java
@@ -4,9 +4,11 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.view.View;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.ImageView;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -61,6 +63,7 @@ public class CommunityPostActivity extends AppCompatActivity {
         // Setup UI
         searchInput = findViewById(R.id.searchInput);
         ImageView filterBtn = findViewById(R.id.filterBtn);
+        TextView activeFilterLabel = findViewById(R.id.activeFilterLabel);
         filterBtn.setOnClickListener(v -> {
             String[] fields = {"All", "Username", "Date", "Title", "Description", "Likes", "Comments"};
             new androidx.appcompat.app.AlertDialog.Builder(this)
@@ -68,12 +71,21 @@ public class CommunityPostActivity extends AppCompatActivity {
                     .setItems(fields, (dialog, which) -> {
                         selectedField = fields[which].toLowerCase();
                         adapter.filter(searchInput.getText().toString(), selectedField);
+                        activeFilterLabel.setText(fields[which]);
+                        activeFilterLabel.setVisibility(View.VISIBLE);
                     })
                     .show();
         });
 
         ImageView clearSearch = findViewById(R.id.clearSearch);
-        clearSearch.setOnClickListener(v -> searchInput.setText(""));
+        clearSearch.setOnClickListener(v -> {
+            searchInput.setText("");
+            activeFilterLabel.setText("");
+            activeFilterLabel.setVisibility(View.GONE);
+            selectedField = "all";
+            adapter.filter("", "all");
+        });
+
 
         postsRecyclerView = findViewById(R.id.postsRecyclerView);
         postsRecyclerView.setLayoutManager(new LinearLayoutManager(this));

--- a/app/src/main/res/layout/activity_communityposts.xml
+++ b/app/src/main/res/layout/activity_communityposts.xml
@@ -101,6 +101,17 @@
             android:layout_centerVertical="true"
             android:src="@drawable/filter_svg"
             android:contentDescription="Filter options" />
+        <TextView
+            android:id="@+id/activeFilterLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_toStartOf="@id/filterBtn"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="4dp"
+            android:text=""
+            android:textSize="12sp"
+            android:textColor="@android:color/holo_blue_dark"
+            android:visibility="gone"/>
     </RelativeLayout>
 
     <!-- Posts List using recyclerview i.e. CommunityPostAdapter.java -->


### PR DESCRIPTION
## Summary
On the Community Posts screen, selecting a filter from the funnel 
button showed no visual indication of which filter was active, 
making the X button meaningless.

## Changes Made
- Added activeFilterLabel TextView to activity_communityposts.xml
- Wired up label to show selected filter name after selection
- Updated clearSearch button to also reset the filter label and 
  restore default filter state

## Testing
- Tested all filter options on Android emulator (Medium Phone API 37.0)
- Confirmed selected filter name appears next to funnel icon
- Confirmed X button clears both search text and filter label

## Planner Task
[Fix Posts Filter Selection Not Showing Active State - Microsoft Planner]