### PR TITLE
fix(home): lighten counter button colours and improve spacing

### DIFF
--- a/app/src/main/res/drawable/counter_buttons.xml
+++ b/app/src/main/res/drawable/counter_buttons.xml
@@ -2,13 +2,12 @@
 <shape
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <corners  android:radius="10dp"/>
+    <corners android:radius="10dp"/>
 
     <gradient
         android:type="linear"
-        android:startColor="#D4F1F4"
-        android:endColor="#05445E"
-        android:angle="90"
-        />
+        android:startColor="#E8F8FA"
+        android:endColor="#B2EBF2"
+        android:angle="90"/>
 
 </shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -311,7 +311,7 @@
                 android:layout_height="wrap_content"
                 android:text="Learn More About Smishing"
                 android:textSize="16sp"
-                android:layout_marginTop="8dp"
+                android:layout_marginTop="24dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp"
                 android:background="@drawable/buttons_rounded"


### PR DESCRIPTION
## Summary
The Home screen UI had dark heavy button colours and inconsistent 
spacing making the screen look cluttered and unpolished.

## Changes Made
- Lightened the counter_buttons drawable gradient from dark navy 
  to a soft light cyan for a cleaner look
- Increased spacing between View Detections/Risk Scanner buttons 
  and Learn More About Smishing button from 8dp to 24dp

## Testing
- Tested on Android emulator (Medium Phone API 37.0)
- Confirmed buttons look lighter and more consistent
- Confirmed spacing is more balanced on the home screen

## Planner Task
[Fix Home Screen UI - Button Colours, Alignment and Spacing - Microsoft Planner]