### PR TITLE
feat(settings): add password and security screen and navigation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,6 +69,7 @@
         <activity android:name=".TermsAndConditionsActivity" android:exported="false" />
         <activity android:name=".SignupActivity" android:exported="false" />
         <activity android:name=".SettingsActivity" android:exported="false" />
+        <activity android:name=".PasswordSecurityActivity" android:exported="false" />
 
         <!-- News -->
         <activity android:name=".NewsActivity" android:exported="false" />

--- a/app/src/main/AndroidManifest.xml.orig
+++ b/app/src/main/AndroidManifest.xml.orig
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Permissions -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_SMS" />
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.CALL_PHONE" />
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+
+
+    <!-- Legacy write permission (only up to Android 9 / API 28) -->
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+
+    <!-- Optional Features -->
+    <uses-feature
+        android:name="android.hardware.telephony"
+        android:required="false" />
+
+    <!-- Declare camera as optional to avoid Play Store filtering -->
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera.front"
+        android:required="false" />
+
+    <application
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:icon="@drawable/new_logo"
+        android:label="@string/app_name"
+        android:roundIcon="@drawable/new_logo"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.SmishingDetectionApp"
+        android:usesCleartextTraffic="false"
+        tools:targetApi="31">
+
+        <!-- Chat History Activity -->
+        <activity
+            android:name=".chat.ChatHistoryActivity"
+            android:exported="false" />
+
+        <!-- Launcher -->
+        <activity
+            android:name=".SplashScreen"
+            android:exported="true"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <!-- Core Pages -->
+        <activity android:name=".MainActivity" android:exported="true" />
+        <activity android:name=".EducationActivity" />
+        <activity android:name=".AboutUsActivity" />
+        <activity android:name=".HelpActivity" android:exported="false" />
+        <activity android:name=".TermsAndConditionsActivity" android:exported="false" />
+        <activity android:name=".SignupActivity" android:exported="false" />
+        <activity android:name=".SettingsActivity" android:exported="false" />
+
+        <!-- News -->
+        <activity android:name=".NewsActivity" android:exported="false" />
+        <activity android:name=".news.SavedNewsActivity" android:exported="false" />
+
+        <!-- Quiz -->
+        <activity android:name=".QuizesActivity" />
+        <activity android:name=".QuizResultActivity" />
+        <activity android:name=".TopicDetailActivity" />
+
+        <!-- Notifications & SMS -->
+        <activity android:name=".NotificationActivity" android:exported="false" />
+        <activity android:name=".SmsActivity" android:exported="false" />
+        <activity android:name=".SMSMessageDetailActivity" android:exported="false" />
+        <activity android:name=".SmishingRulesActivity" android:exported="false" />
+
+        <!-- Debug & Account -->
+        <activity android:name=".DebugActivity" android:exported="false" />
+        <activity android:name=".AboutMeActivity" android:exported="false" />
+        <activity android:name=".ui.account.AccountActivity" android:exported="true" />
+        <activity android:name=".ui.account.PopupDEL" />
+
+        <!-- Onboarding & Auth -->
+        <activity android:name=".ui.onboarding.OnboardingActivity" android:exported="true" />
+        <activity android:name=".ui.onboarding.LoginCreateActivity" android:exported="false" />
+        <activity android:name=".ui.login.LoginActivity" android:exported="true" />
+        <activity android:name=".ui.Register.RegisterMain" android:exported="true" />
+        <activity android:name=".ui.Register.EmailVerify" android:exported="false" />
+
+        <!-- Detection -->
+        <activity android:name=".detections.DetectionsActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <activity android:name=".detections.YourReportsActivity" android:exported="false" />
+
+        <!-- Risk Meter -->
+        <activity android:name=".riskmeter.RiskScannerTCActivity" android:exported="true" />
+        <activity android:name=".riskmeter.RiskScannerActivity" android:exported="true" />
+        <activity android:name=".riskmeter.RiskResultActivity" android:exported="true" />
+
+<<<<<<< HEAD
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity> <!-- MainActivity is not the launcher anymore -->
+        <activity android:name=".ui.login.ForgotPasswordActivity"/>
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:theme="@style/Theme.SmishingDetectionApp.NoActionBar" />
+        <activity
+            android:name=".FeedbackActivity"
+            android:exported="false" />
+        <activity
+            android:name=".ForumActivity"
+            android:exported="false" />
+=======
+        <!-- UI Pages -->
+        <activity android:name=".ui.CaseStudiesActivity" android:exported="false" />
+        <activity android:name=".ui.SmishingTrendsActivity" android:exported="false" />
+        <activity android:name=".ui.ContactUsActivity" />
+        <activity android:name=".ui.Submissionscreen" android:exported="false" />
+
+        <!-- Chat -->
+>>>>>>> upstream/dev
+        <activity
+            android:name=".chat.ChatAssistantActivity"
+            android:exported="false"
+            android:label="@string/chat_assistant_page" />
+
+        <!-- FAQ -->
+        <activity android:name=".ui.FaqActivity" android:exported="false" />
+
+        <!-- Community -->
+        <activity android:name=".Community.CommunityHomeActivity" />
+        <activity android:name=".Community.CommunityOpenPost" />
+        <activity android:name=".Community.CommunityNewPost" />
+        <activity android:name=".Community.CommunityPostActivity" />
+        <activity
+            android:name=".Community.CommunityReportActivity"
+            android:label="Community – Report" />
+
+        <!-- Feedback -->
+        <activity android:name=".FeedbackActivity" android:exported="false" />
+        <activity android:name=".FeedbackHistoryActivity" android:exported="false" />
+
+        <!-- Radar -->
+        <activity android:name=".RadarActivity" android:exported="true" />
+
+        <!-- File Provider (for Export Chat History) -->
+
+
+        <!-- File Provider -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+        <activity
+            android:name=".ui.SupportFeedbackActivity"
+            android:exported="false"
+            android:label="@string/support_feedback_title" />
+        <activity android:name=".ui.SupportFeedbackDetailsActivity"
+            android:exported="false"
+            android:label="@string/support_feedback_details_title" />
+
+        <!-- Widgets -->
+        <receiver android:name=".ui.SmishingWidgetSmall" android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_small_info" />
+        </receiver>
+
+        <receiver android:name=".ui.SmishingWidgetMedium" android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_medium_info" />
+        </receiver>
+
+        <receiver android:name=".ui.SmishingWidgetLarge" android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_large_info" />
+        </receiver>
+
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/smishingdetectionapp/Community/CommunityPostActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/Community/CommunityPostActivity.java
@@ -4,9 +4,11 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.view.View;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.ImageView;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -61,6 +63,7 @@ public class CommunityPostActivity extends AppCompatActivity {
         // Setup UI
         searchInput = findViewById(R.id.searchInput);
         ImageView filterBtn = findViewById(R.id.filterBtn);
+        TextView activeFilterLabel = findViewById(R.id.activeFilterLabel);
         filterBtn.setOnClickListener(v -> {
             String[] fields = {"All", "Username", "Date", "Title", "Description", "Likes", "Comments"};
             new androidx.appcompat.app.AlertDialog.Builder(this)
@@ -68,12 +71,21 @@ public class CommunityPostActivity extends AppCompatActivity {
                     .setItems(fields, (dialog, which) -> {
                         selectedField = fields[which].toLowerCase();
                         adapter.filter(searchInput.getText().toString(), selectedField);
+                        activeFilterLabel.setText(fields[which]);
+                        activeFilterLabel.setVisibility(View.VISIBLE);
                     })
                     .show();
         });
 
         ImageView clearSearch = findViewById(R.id.clearSearch);
-        clearSearch.setOnClickListener(v -> searchInput.setText(""));
+        clearSearch.setOnClickListener(v -> {
+            searchInput.setText("");
+            activeFilterLabel.setText("");
+            activeFilterLabel.setVisibility(View.GONE);
+            selectedField = "all";
+            adapter.filter("", "all");
+        });
+
 
         postsRecyclerView = findViewById(R.id.postsRecyclerView);
         postsRecyclerView.setLayoutManager(new LinearLayoutManager(this));

--- a/app/src/main/java/com/example/smishingdetectionapp/PasswordSecurityActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/PasswordSecurityActivity.java
@@ -1,0 +1,13 @@
+package com.example.smishingdetectionapp;
+
+import android.os.Bundle;
+import androidx.appcompat.app.AppCompatActivity;
+
+public class PasswordSecurityActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_password_security);
+    }
+}

--- a/app/src/main/java/com/example/smishingdetectionapp/SettingsActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/SettingsActivity.java
@@ -154,6 +154,12 @@ public class SettingsActivity extends AppCompatActivity {
             startActivity(new Intent(this, NotificationActivity.class));
         });
 
+        // Password and Security button
+        Button passwordBtn = findViewById(R.id.passwordBtn);
+        passwordBtn.setOnClickListener(v -> {
+            startActivity(new Intent(this, PasswordSecurityActivity.class));
+        });
+
         // Filtering button to switch to Smishing rules page
         ImageView filteringBtn = findViewById(R.id.imageView7);
         if (filteringBtn != null) {
@@ -405,12 +411,6 @@ public class SettingsActivity extends AppCompatActivity {
         });
     }
 
-    // Open AccountActivity directly
-    private void openAccountActivity() {
-        startActivity(new Intent(SettingsActivity.this, AccountActivity.class));
-        finish();
-    }
-
     private void restoreScrollPosition() {
         savedPosition = prefs.getInt("scroll_pos", 0);
         if (isTaskRoot()) {
@@ -431,10 +431,5 @@ public class SettingsActivity extends AppCompatActivity {
         if (!prefs.getBoolean("cold_start", false)) {
             restoreScrollPosition();
         }
-    }
-}
-    // Notification button
-    public void openNotificationsActivity(View view) {
-        startActivity(new Intent(this, NotificationActivity.class));
     }
 }

--- a/app/src/main/java/com/example/smishingdetectionapp/news/NewsRequestManager.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/news/NewsRequestManager.java
@@ -1,5 +1,6 @@
 package com.example.smishingdetectionapp.news;
 
+import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
 import retrofit2.converter.simplexml.SimpleXmlConverterFactory;
 import retrofit2.Call;
@@ -18,8 +19,13 @@ public class NewsRequestManager {
 
     // Fetches RSS feed from a specified site using Retrofit and notifies the listener.
     public void fetchRSSFeed(OnFetchDataListener<RSSFeedModel.Feed> listener) {
+        OkHttpClient client = new OkHttpClient.Builder()
+                .connectTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
+                .readTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
+                .build();
         Retrofit retrofit = new Retrofit.Builder()
-                .baseUrl("https://www.scamwatch.gov.au/rss/news-feed.xml/") // Example base URL
+                .baseUrl("https://www.scamwatch.gov.au/rss/news-feed.xml/")// Example base UR// L
+                .client(client)
                 .addConverterFactory(SimpleXmlConverterFactory.create())
                 .build();
 

--- a/app/src/main/java/com/example/smishingdetectionapp/ui/login/ForgotPasswordActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/ui/login/ForgotPasswordActivity.java
@@ -1,0 +1,21 @@
+package com.example.smishingdetectionapp.ui.login;
+
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.Toast;
+import androidx.appcompat.app.AppCompatActivity;
+import com.example.smishingdetectionapp.R;
+
+public class ForgotPasswordActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_forgot_password);
+
+        Button sendResetBtn = findViewById(R.id.sendResetLink);
+        sendResetBtn.setOnClickListener(v -> {
+            Toast.makeText(this, "Reset link sent to your email!", Toast.LENGTH_SHORT).show();
+        });
+    }
+}

--- a/app/src/main/java/com/example/smishingdetectionapp/ui/login/LoginActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/ui/login/LoginActivity.java
@@ -9,6 +9,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.ProgressBar;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
@@ -41,6 +42,7 @@ import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 import java.util.HashMap;
+import com.example.smishingdetectionapp.ui.login.ForgotPasswordActivity;
 
 public class LoginActivity extends AppCompatActivity {
 
@@ -89,7 +91,8 @@ public class LoginActivity extends AppCompatActivity {
         final SignInButton googleBtn = binding.googleBtn;
         final Button registerButton = binding.registerButton;
         final ImageButton togglePasswordVisibility = binding.togglePasswordVisibility;
-        final Button togglePinLogin = (Button) binding.togglePinLogin;  // Added missing reference for togglePinLogin button
+        final Button togglePinLogin = binding.togglePinLogin;
+        final TextView forgotPasswordButton = binding.forgotPasswordButton;
 
         // Toggle functionality for PIN and Password login
         togglePinLogin.setOnClickListener(v -> {
@@ -129,6 +132,12 @@ public class LoginActivity extends AppCompatActivity {
                 }
                 loginWithPassword(email, input);
             }
+        });
+
+        // Handle forgot password click
+        forgotPasswordButton.setOnClickListener(v -> {
+            Intent intent = new Intent(LoginActivity.this, ForgotPasswordActivity.class);
+            startActivity(intent);
         });
 
         // Handle register button click

--- a/app/src/main/res/drawable/counter_buttons.xml
+++ b/app/src/main/res/drawable/counter_buttons.xml
@@ -2,13 +2,12 @@
 <shape
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <corners  android:radius="10dp"/>
+    <corners android:radius="10dp"/>
 
     <gradient
         android:type="linear"
-        android:startColor="#D4F1F4"
-        android:endColor="#05445E"
-        android:angle="90"
-        />
+        android:startColor="#E8F8FA"
+        android:endColor="#B2EBF2"
+        android:angle="90"/>
 
 </shape>

--- a/app/src/main/res/layout/activity_communityposts.xml
+++ b/app/src/main/res/layout/activity_communityposts.xml
@@ -101,6 +101,17 @@
             android:layout_centerVertical="true"
             android:src="@drawable/filter_svg"
             android:contentDescription="Filter options" />
+        <TextView
+            android:id="@+id/activeFilterLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_toStartOf="@id/filterBtn"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="4dp"
+            android:text=""
+            android:textSize="12sp"
+            android:textColor="@android:color/holo_blue_dark"
+            android:visibility="gone"/>
     </RelativeLayout>
 
     <!-- Posts List using recyclerview i.e. CommunityPostAdapter.java -->

--- a/app/src/main/res/layout/activity_forgot_password.xml
+++ b/app/src/main/res/layout/activity_forgot_password.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:gravity="center">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Forgot Password"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="16dp"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Enter your email and we'll send you a reset link."
+        android:textSize="14sp"
+        android:gravity="center"
+        android:layout_marginBottom="24dp"/>
+
+    <EditText
+        android:id="@+id/forgotPasswordEmail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Enter your email"
+        android:inputType="textEmailAddress"
+        android:layout_marginBottom="16dp"/>
+
+    <Button
+        android:id="@+id/sendResetLink"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Send Reset Link"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -311,7 +311,7 @@
                 android:layout_height="wrap_content"
                 android:text="Learn More About Smishing"
                 android:textSize="16sp"
-                android:layout_marginTop="8dp"
+                android:layout_marginTop="24dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp"
                 android:background="@drawable/buttons_rounded"

--- a/app/src/main/res/layout/activity_password_security.xml
+++ b/app/src/main/res/layout/activity_password_security.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Password and Security"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="24dp"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Manage your password and security settings here."
+        android:textSize="14sp"
+        android:layout_marginBottom="24dp"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/changePasswordBtn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Change Password"
+        android:layout_marginBottom="12dp"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/changePinBtn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Change PIN"
+        android:layout_marginBottom="12dp"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/twoFactorBtn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Two-Factor Authentication"/>
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
The "Password and Security" button in the Settings screen was not 
navigating anywhere when tapped. The button existed in the layout 
but had no click listener or target screen configured.

## Changes Made
- Created PasswordSecurityActivity.java
- Created activity_password_security.xml layout with Change Password,
  Change PIN and Two-Factor Authentication buttons
- Registered PasswordSecurityActivity in AndroidManifest.xml
- Wired up click listener in SettingsActivity.java

## Testing
- Tested on Android emulator (Medium Phone API 37.0)
- Confirmed Password and Security button navigates correctly
- Confirmed new screen displays all options correctly

## Planner Task
[Fix Password and Security Navigation - Microsoft Planner]