### PR TITLE
feat(riskscanner): migrate the risk scanner logic to shared module

### DIFF
--- a/app/src/main/java/com/example/smishingdetectionapp/riskmeter/RiskResultActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/riskmeter/RiskResultActivity.java
@@ -72,7 +72,9 @@ public class RiskResultActivity extends AppCompatActivity {
         RiskScannerLogic.scanHabits(this, progressBar, riskLevelText,
                 lightAgeGroup, lightSmsApp, lightSecurityApp, lightSpamFilter,
                 lightDeviceLock, lightUnknownSources, lightSmsBehaviour, disableSmsRisk,
-                disableAgeRisk, disableSecurityRisk);
+                disableAgeRisk, disableSecurityRisk, 23);
+
+        animateProgress(progressBar, percentageText, RiskScannerLogic.getCalculatedScore());
 
         // this is for view anlysis text to make it a clickable text view
         TextView viewAnalysisText = findViewById(R.id.textViewRiskDetails);

--- a/app/src/main/java/com/example/smishingdetectionapp/riskmeter/RiskScannerLogic.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/riskmeter/RiskScannerLogic.java
@@ -1,10 +1,6 @@
 package com.example.smishingdetectionapp.riskmeter;
 
 import android.content.Context;
-import android.os.Build;
-import android.provider.Settings;
-import android.content.pm.PackageManager;
-import android.app.KeyguardManager;
 import android.view.View;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -12,6 +8,12 @@ import android.widget.TextView;
 import androidx.core.content.ContextCompat;
 
 import com.example.smishingdetectionapp.R;
+import com.example.smishingdetectionapp.domain.riskscanner.AndroidRiskCheckProvider;
+import com.example.smishingdetectionapp.domain.riskscanner.RiskCheckResult;
+import com.example.smishingdetectionapp.domain.riskscanner.RiskScannerEngine;
+import com.example.smishingdetectionapp.domain.riskscanner.RiskScore;
+
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,9 +24,11 @@ public class RiskScannerLogic {
 
     // this is to list the specific risk factors that were factored for our detected issues feedback
     private static final List<String> triggeredRisks = new ArrayList<>();
+    private static @NotNull List<@NotNull RiskCheckResult> checkResults = new ArrayList<>();
 
+    // this is the main method and delegates to shared engine, then updates UI
     public static void scanHabits(
-            RiskResultActivity activity,
+            Context context,
             ProgressBar progressBar,
             TextView riskLevelText,
             View lightAgeGroup, View lightSmsApp, View lightSecurityApp,
@@ -32,88 +36,35 @@ public class RiskScannerLogic {
             View lightSmsBehaviour,
             boolean disableSmsRisk,
             boolean disableAgeRisk,
-            boolean disableSecurityRisk
+            boolean disableSecurityRisk,
+            int userAge
     ) {
+        AndroidRiskCheckProvider provider = new AndroidRiskCheckProvider(context);
+        RiskScore score = RiskScannerEngine.INSTANCE.scanHabits(
+                provider, disableSmsRisk, disableAgeRisk, disableSecurityRisk, userAge
+        );
+
+        calculatedScore = score.getTotalScore();
         triggeredRisks.clear();
-        int totalScore = 0;
+        triggeredRisks.addAll(score.getTriggeredRisks());
+        checkResults = new ArrayList<>(score.getCheckResults());
 
-        // our aged-based adjustments (hardcoded for now but with sign-up API this will be dynamic)
-        if (!disableAgeRisk) {
-            int userAge = 23;
-            int ageGroupRisk = calculateAgeGroupRisk(userAge);
-            totalScore += ageGroupRisk;
-            if (ageGroupRisk > 0) {
-                triggeredRisks.add("You are in a higher risk age group.");
+        for (RiskCheckResult result : checkResults) {
+            String color = result.getPassed() ? "#66BB6A" : "#EF5350";
+            switch (result.getName()) {
+                case "Age Group":       setLightColor(lightAgeGroup, color); break;
+                case "SMS Behaviour":   setLightColor(lightSmsBehaviour, color); break;
+                case "Security App":    setLightColor(lightSecurityApp, color); break;
+                case "Spam Filter":     setLightColor(lightSpamFilter, color); break;
+                case "Device Lock":     setLightColor(lightDeviceLock, color); break;
+                case "Unknown Sources": setLightColor(lightUnknownSources, color); break;
+                case "SMS App":         setLightColor(lightSmsApp, color); break;
             }
-            setLightColor(lightAgeGroup, ageGroupRisk > 0 ? "#EF5350" : "#66BB6A");
-        } else {
-            setLightColor(lightAgeGroup, "#B0B0B0"); // grey (not applied)
         }
 
-        // checking for sms risk behaviour
-        if (!disableSmsRisk) {
-            boolean smsBehaviorRisk = checkSmsBehavior(activity);
-            totalScore += smsBehaviorRisk ? 15 : 0;
-            if (smsBehaviorRisk) {
-                triggeredRisks.add("Some SMS messages on your device appear to be potentially suspicious.");
-            }
-            setLightColor(lightSmsBehaviour, smsBehaviorRisk ? "#EF5350" : "#66BB6A");
-        } else {
-            setLightColor(lightSmsBehaviour, "#B0B0B0");
-        }
+        riskLevelText.setText(score.getRiskLevel());
+        updateProgressBarColor(progressBar, calculatedScore);
 
-        // checking for security apps, spam filters, and lock screen
-        if (!disableSecurityRisk) {
-            boolean securityAppInstalled = checkSecurityApps(activity);
-            totalScore += securityAppInstalled ? 0 : 14;
-            if (!securityAppInstalled) {
-                triggeredRisks.add("No trusted security apps were found on your device.");
-            }
-            setLightColor(lightSecurityApp, securityAppInstalled ? "#66BB6A" : "#EF5350");
-
-            boolean spamFilterInstalled = checkSpamFilterApp(activity);
-            totalScore += spamFilterInstalled ? 0 : 14;
-            if (!spamFilterInstalled) {
-                triggeredRisks.add("No spam filter was detected on your device.");
-            }
-            setLightColor(lightSpamFilter, spamFilterInstalled ? "#66BB6A" : "#EF5350");
-
-            boolean deviceSecured = checkDeviceLock(activity);
-            totalScore += deviceSecured ? 0 : 14;
-            if (!deviceSecured) {
-                triggeredRisks.add("Your device has no lock screen (PIN or password).");
-            }
-            setLightColor(lightDeviceLock, deviceSecured ? "#66BB6A" : "#EF5350");
-        } else {
-            setLightColor(lightSecurityApp, "#B0B0B0");
-            setLightColor(lightSpamFilter, "#B0B0B0");
-            setLightColor(lightDeviceLock, "#B0B0B0");
-        }
-
-        // unknown sources enabled
-        boolean unknownSourcesEnabled = checkUnknownSources(activity);
-        totalScore += unknownSourcesEnabled ? 14 : 0;
-        if (unknownSourcesEnabled) {
-            triggeredRisks.add("Your device allows app installations from unknown sources.");
-        }
-        setLightColor(lightUnknownSources, unknownSourcesEnabled ? "#EF5350" : "#66BB6A");
-
-        // sms app trusted or not
-        boolean trustedSmsApp = checkTrustedSmsApp(activity);
-        totalScore += trustedSmsApp ? 0 : 14;
-        if (!trustedSmsApp) {
-            triggeredRisks.add("Your current SMS app may not be from a trusted provider.");
-        }
-        setLightColor(lightSmsApp, trustedSmsApp ? "#66BB6A" : "#EF5350");
-
-        // limiting score to max 100
-        if (totalScore > 100) totalScore = 100;
-
-        calculatedScore = totalScore;
-
-        updateRiskLevel(riskLevelText, totalScore);
-        updateProgressBarColor(progressBar, totalScore);
-        activity.animateProgress(progressBar, activity.percentageText, totalScore);
     }
 
     public static int getCalculatedScore() {
@@ -124,7 +75,7 @@ public class RiskScannerLogic {
         return triggeredRisks;
     }
 
-    // colour coordinating the progress bar based on risk level
+    // color coordinating the progress bar based on risk level
     private static void updateProgressBarColor(ProgressBar progressBar, int score) {
         if (score <= 30) {
             progressBar.setProgressTintList(ContextCompat.getColorStateList(progressBar.getContext(), R.color.green));
@@ -135,89 +86,8 @@ public class RiskScannerLogic {
         }
     }
 
-    // dynamically changing risk level text based on score
-    private static void updateRiskLevel(TextView riskLevelText, int totalScore) {
-        String riskLevel;
-        if (totalScore <= 30) {
-            riskLevel = "Low Risk";
-        } else if (totalScore <= 60) {
-            riskLevel = "Moderate Risk";
-        } else {
-            riskLevel = "High Risk";
-        }
-        riskLevelText.setText(riskLevel);
-    }
-
-    // our scores for the ages
-    private static int calculateAgeGroupRisk(int age) {
-        if (age >= 18 && age <= 24) return 15;
-        if (age >= 25 && age <= 34) return 10;
-        return 0;
-    }
-
-    private static boolean checkSmsBehavior(Context context) {
-        return false;  // this is for aaliyan to contribute to
-    }
-
-    // checking for popular security apps downloaded
-    private static boolean checkSecurityApps(Context context) {
-        PackageManager pm = context.getPackageManager();
-        String[] knownSecurityApps = {"com.norton.mobilesecurity", "com.mcafee.android", "com.bitdefender.antivirus"};
-        for (String app : knownSecurityApps) {
-            try {
-                pm.getPackageInfo(app, 0);
-                return true;
-            } catch (PackageManager.NameNotFoundException ignored) { }
-        }
-        return false;
-    }
-
-    // checking if spam filter could be enabled as with google messages or other apps
-    private static boolean checkSpamFilterApp(Context context) {
-        PackageManager pm = context.getPackageManager();
-        String[] spamFilters = {"com.google.android.apps.messaging", "com.mrnumber.blocker", "com.truecaller"};
-        for (String app : spamFilters) {
-            try {
-                pm.getPackageInfo(app, 0);
-                return true;
-            } catch (PackageManager.NameNotFoundException ignored) { }
-        }
-        return false;
-    }
-
-    private static boolean checkDeviceLock(Context context) {
-        KeyguardManager km = (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
-        return km != null && km.isDeviceSecure();
-    }
-
-    // this will depend on the android version currently we can check settings
-    private static boolean checkUnknownSources(Context context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            return context.getPackageManager().canRequestPackageInstalls();
-        } else {
-            try {
-                return Settings.Secure.getInt(context.getContentResolver(),
-                        Settings.Secure.INSTALL_NON_MARKET_APPS) == 1;
-            } catch (Settings.SettingNotFoundException e) {
-                return false;
-            }
-        }
-    }
-
-    private static boolean checkTrustedSmsApp(Context context) {
-        String defaultSmsApp = Settings.Secure.getString(context.getContentResolver(), "sms_default_application");
-        return defaultSmsApp != null && (
-                defaultSmsApp.contains("messages") || defaultSmsApp.contains("samsung")
-        );
-    }
-
     private static void setLightColor(View view, String color) {
         view.setBackgroundTintList(android.content.res.ColorStateList.valueOf(android.graphics.Color.parseColor(color)));
     }
 
-    private static String getColorForRisk(int risk) {
-        if (risk <= 30) return "#66BB6A";  // green
-        if (risk <= 60) return "#FFEB3B";  // yellow
-        return "#EF5350";                 // red
-    }
 }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,6 +7,8 @@
  <color name="teal_700">#FF018786</color>
  <color name="black">#FF000000</color>
  <color name="white">#FFFFFFFF</color>
+ <color name="background_light">#FFFFFF</color>
+ <color name="light_gray">#D3D3D3</color>
 
  <!-- New Colors -->
  <color name="navy_blue">#FF05445E</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -474,6 +474,13 @@
     <string name="Forums_and_Report">Forums &amp; Report</string>
     <string name="word_count_format">Words: %1$d / %2$d</string>
     <string name="feedback_success">Feedback submitted successfully!</string>
+    <string name="view_profile">View Profile</string>
+    <string name="user_profile_title">User Profile</string>
+    <string name="profile_picture_desc">Profile Picture</string>
+    <string name="address_label">Address</string>
+    <string name="edit_button">Edit</string>
+    <string name="view_risk_profile">View Risk Profile</string>
+    <string name="save_button">Save</string>
 
     <string name="invite_friend">Invite a Friend</string>
     <string name="share_to_story">Share to story</string>

--- a/shared/src/androidMain/kotlin/com/example/smishingdetectionapp/domain/riskscanner/AndroidRiskCheckProvider.kt
+++ b/shared/src/androidMain/kotlin/com/example/smishingdetectionapp/domain/riskscanner/AndroidRiskCheckProvider.kt
@@ -1,0 +1,84 @@
+package com.example.smishingdetectionapp.domain.riskscanner
+
+import android.app.KeyguardManager
+import android.content.Context
+import android.os.Build
+import android.provider.Settings
+
+class AndroidRiskCheckProvider(private val context: Context) : RiskCheckProvider {
+
+    private val knownSecurityApps = listOf(
+        "com.norton.mobilesecurity",
+        "com.mcafee.android",
+        "com.bitdefender.antivirus"
+    )
+
+    private val knownSpamFilters = listOf(
+        "com.google.android.apps.messaging",
+        "com.mrnumber.blocker",
+        "com.truecaller"
+    )
+
+
+    override fun hasSuspiciousSms(): Boolean {
+        //Unimplemented
+        return false
+
+
+    }
+
+    override fun hasSecurityApp(): Boolean {
+        val pm = context.packageManager
+        return knownSecurityApps.any {app ->
+            try {
+                pm.getPackageInfo(app, 0)
+                true
+            } catch (e: Exception) {
+                false
+            }
+        }
+    }
+
+    override fun hasSpamFilter(): Boolean {
+        val pm = context.packageManager
+        return knownSpamFilters.any {app ->
+            try {
+                pm.getPackageInfo(app, 0)
+                true
+            } catch (e: Exception) {
+                false
+            }
+        }
+    }
+
+    override fun isDeviceSecured(): Boolean {
+        val km = context.getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
+        return km?.isDeviceSecure == true
+    }
+
+    override fun hasUnknownSourcesEnabled(): Boolean {
+        // check if SmishingDetectionApp can install unknown apps
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.packageManager.canRequestPackageInstalls()
+        } else {
+            try {
+                Settings.Secure.getInt(
+                    context.contentResolver,
+                    Settings.Secure.INSTALL_NON_MARKET_APPS
+                ) == 1
+            } catch (e: Exception) {
+                false
+            }
+        }
+    }
+
+    override fun hasTrustedSmsApp(): Boolean {
+        val defaultSmsApp = Settings.Secure.getString(
+            context.contentResolver,
+            "sms_default_application"
+        )
+        return defaultSmsApp != null && (
+                defaultSmsApp.contains("messages") || defaultSmsApp.contains("samsung")
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/example/smishingdetectionapp/domain/riskscanner/RiskCheckProvider.kt
+++ b/shared/src/commonMain/kotlin/com/example/smishingdetectionapp/domain/riskscanner/RiskCheckProvider.kt
@@ -1,0 +1,11 @@
+package com.example.smishingdetectionapp.domain.riskscanner
+
+// Platform-specific checks. Each platform implements this differently.
+interface RiskCheckProvider {
+    fun hasSuspiciousSms(): Boolean
+    fun hasSecurityApp(): Boolean
+    fun hasSpamFilter(): Boolean
+    fun isDeviceSecured(): Boolean
+    fun hasUnknownSourcesEnabled(): Boolean
+    fun hasTrustedSmsApp(): Boolean
+}

--- a/shared/src/commonMain/kotlin/com/example/smishingdetectionapp/domain/riskscanner/RiskScannerEngine.kt
+++ b/shared/src/commonMain/kotlin/com/example/smishingdetectionapp/domain/riskscanner/RiskScannerEngine.kt
@@ -1,0 +1,129 @@
+package com.example.smishingdetectionapp.domain.riskscanner
+
+// Logic for calculating risk scores
+// Platform-specific checks are injected via RiskCheckProvider
+object RiskScannerEngine {
+
+    // Age-based risk scoring
+    fun calculateAgeGroupRisk(age: Int): Int {
+        return when {
+            age in 18..24 -> 15
+            age in 25..34 -> 10
+            else -> 0
+        }
+    }
+
+    fun scanHabits(
+        provider: RiskCheckProvider,
+        disableSmsRisk: Boolean = false,
+        disableAgeRisk: Boolean = false,
+        disableSecurityRisk: Boolean = false,
+        userAge: Int = 0
+    ): RiskScore {
+        val results = mutableListOf<RiskCheckResult>()
+        var totalScore = 0
+
+        // Age risk
+        if (!disableAgeRisk) {
+            val ageRisk = calculateAgeGroupRisk(userAge)
+            results.add(RiskCheckResult(
+                name = "Age Group",
+                passed = ageRisk == 0,
+                riskPoints = ageRisk,
+                failureMessage = "You are in a higher risk age group."
+            ))
+            totalScore += ageRisk
+        } else {
+            results.add(RiskCheckResult(
+                name = "Age Group",
+                passed = true,
+                riskPoints = 0,
+                failureMessage = ""
+            ))
+        }
+
+        // SMS behaviour
+        if (!disableSmsRisk) {
+            val smsRisk = provider.hasSuspiciousSms()
+            results.add(RiskCheckResult(
+                name = "SMS Behaviour",
+                passed = !smsRisk,
+                riskPoints = if (smsRisk) 15 else 0,
+                failureMessage = "Some SMS messages on your device appear to be potentially suspicious."
+            ))
+            totalScore += if (smsRisk) 15 else 0
+        } else {
+            results.add(RiskCheckResult(
+                name = "SMS Behaviour",
+                passed = true,
+                riskPoints = 0,
+                failureMessage = ""
+            ))
+        }
+
+        // Security checks
+        if (!disableSecurityRisk) {
+            val hasSecurityApp = provider.hasSecurityApp()
+            results.add(RiskCheckResult(
+                name = "Security App",
+                passed = hasSecurityApp,
+                riskPoints = if (!hasSecurityApp) 14 else 0,
+                failureMessage = "No trusted security apps were found on your device."
+            ))
+            totalScore += if (!hasSecurityApp) 14 else 0
+
+            val hasSpamFilter = provider.hasSpamFilter()
+            results.add(RiskCheckResult(
+                name = "Spam Filter",
+                passed = hasSpamFilter,
+                riskPoints = if (!hasSpamFilter) 14 else 0,
+                failureMessage = "No spam filter was detected on your device."
+            ))
+            totalScore += if (!hasSpamFilter) 14 else 0
+
+            val isDeviceSecured = provider.isDeviceSecured()
+            results.add(RiskCheckResult(
+                name = "Device Lock",
+                passed = isDeviceSecured,
+                riskPoints = if (!isDeviceSecured) 14 else 0,
+                failureMessage = "Your device has no lock screen (PIN or password)."
+            ))
+            totalScore += if (!isDeviceSecured) 14 else 0
+        } else {
+            results.add(RiskCheckResult("Security App", true, 0, ""))
+            results.add(RiskCheckResult("Spam Filter", true, 0, ""))
+            results.add(RiskCheckResult("Device Lock", true, 0, ""))
+        }
+
+        // Unknown sources
+        val unknownSources = provider.hasUnknownSourcesEnabled()
+        results.add(RiskCheckResult(
+            name = "Unknown Sources",
+            passed = !unknownSources,
+            riskPoints = if (unknownSources) 14 else 0,
+            failureMessage = "Your device allows app installations from unknown sources."
+        ))
+        totalScore += if (unknownSources) 14 else 0
+
+        // Trusted SMS app
+        val trustedSms = provider.hasTrustedSmsApp()
+        results.add(RiskCheckResult(
+            name = "SMS App",
+            passed = trustedSms,
+            riskPoints = if (!trustedSms) 14 else 0,
+            failureMessage = "Your current SMS app may not be from a trusted provider."
+        ))
+        totalScore += if (!trustedSms) 14 else 0
+
+        val cappedScore = totalScore.coerceAtMost(100)
+        val triggeredRisks = results
+            .filter { !it.passed && it.riskPoints > 0 }
+            .map { it.failureMessage }
+
+        return RiskScore(
+            totalScore = cappedScore,
+            triggeredRisks = triggeredRisks,
+            checkResults = results
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/example/smishingdetectionapp/domain/riskscanner/RiskScore.kt
+++ b/shared/src/commonMain/kotlin/com/example/smishingdetectionapp/domain/riskscanner/RiskScore.kt
@@ -1,0 +1,40 @@
+package com.example.smishingdetectionapp.domain.riskscanner
+
+// Holds the result of a risk scan
+data class RiskScore (
+    val totalScore: Int,
+    val triggeredRisks: List<String>,
+    val checkResults: List<RiskCheckResult>
+) {
+
+    val riskLevel: String
+        get() = when {
+            totalScore <= 30 -> "Low Risk"
+            totalScore <= 60 -> "Moderate Risk"
+            else -> "High Risk"
+        }
+
+    // List of possible recommendations
+    val recommendations: List<String>
+        get() = if (totalScore > 30) {
+            listOf(
+                "Set up a strong password or PIN to protect your data.",
+                "Install antivirus or security apps to detect suspicious activity.",
+                "Disable installations from unknown sources.",
+                "Enable a spam filter to block smishing messages",
+                "Avoid clicking links in SMS from unknown senders.",
+                "Report suspicious SMS to your mobile provider/organisation.",
+                "Take a cybersecurity awareness course."
+            )
+        } else {
+            listOf("Keep up your excellent security habits! You're doing great.")
+        }
+}
+
+// result of a single risk check
+data class RiskCheckResult(
+    val name: String,
+    val passed: Boolean,
+    val riskPoints: Int,
+    val failureMessage: String
+)

--- a/shared/src/iosMain/kotlin/com/example/smishingdetectionapp/domain/riskscanner/IOSRiskCheckProvider.kt
+++ b/shared/src/iosMain/kotlin/com/example/smishingdetectionapp/domain/riskscanner/IOSRiskCheckProvider.kt
@@ -1,0 +1,47 @@
+package com.example.smishingdetectionapp.domain.riskscanner
+
+import platform.LocalAuthentication.LAContext
+import platform.LocalAuthentication.LAPolicyDeviceOwnerAuthentication
+
+
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+class IOSRiskCheckProvider : RiskCheckProvider {
+    override fun hasSuspiciousSms(): Boolean {
+        // No Implementation
+        // iOS doesn't allow reading SMS
+        return false
+    }
+
+    override fun hasSecurityApp(): Boolean {
+        // No Implementation
+        // iOS doesn't expose installed apps — return false or prompt user
+        return false
+    }
+
+    override fun hasSpamFilter(): Boolean {
+        // iOS 10+ supports SMS filtering extensions
+        // No programmatic way to detect — assume true if on iOS 17+
+        return true
+    }
+
+    override fun isDeviceSecured(): Boolean {
+        val context = LAContext()
+        return context.canEvaluatePolicy(
+            LAPolicyDeviceOwnerAuthentication,
+            error = null
+        )
+    }
+
+    override fun hasUnknownSourcesEnabled(): Boolean {
+        // No Implementation
+        // iOS doesn't allow sideloading — always safe
+        return false
+    }
+
+    override fun hasTrustedSmsApp(): Boolean {
+        // No Implementation
+        // Only Messages app exists — always trusted
+        return true
+    }
+
+}


### PR DESCRIPTION
- Add RiskScannerEngine with pure scoring logic in commonMain
- Add RiskCheckProvider interface for platform-specific security checks
- Add AndroidRiskCheckProvider (KeyguardManager, PackageManager, Settings)
- Add IOSRiskCheckProvider.kt (LAContext, added comments for unsupported checks)
- Refactor RiskScannerLogic.java to delegate scoring to shared engine
- Add userAge parameter to scanHabits
- Fix hasSuspiciousSms() TODO crash by returning false (currently no implementation)
- Fix progress bar animation not being called after scan in RiskResultActivity