### PR TITLE
fix: navigate to DetectionsActivity when total detections card is tapped

### DIFF
--- a/app/src/main/java/com/example/smishingdetectionapp/MainActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/MainActivity.java
@@ -72,6 +72,13 @@ public class MainActivity extends SharedActivity {
                 finish();
             });
         }
+        View totalDetectionsClickTarget = findViewById(R.id.total_detections_container);
+        if (totalDetectionsClickTarget != null) {
+            totalDetectionsClickTarget.setOnClickListener(v -> {
+                startActivity(new Intent(this, DetectionsActivity.class));
+                finish();
+            });
+        }
 
         View scannerClickTarget =
                 findViewById(R.id.risk_scanner_container) != null


### PR DESCRIPTION
Fixed bug where tapping the Total Detections card on the Home screen did not navigate anywhere.

Changes made:
- Added OnClickListener to total_detections_container in MainActivity.java
- Navigates to DetectionsActivity when Total Detections card is tapped