### PR TITLE
fix(quiz): add confirmation dialog when exiting quiz mid-session

### DIFF
--- a/app/src/main/java/com/example/smishingdetectionapp/QuizesActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/QuizesActivity.java
@@ -10,6 +10,7 @@ import android.widget.RadioGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.example.smishingdetectionapp.navigation.BottomNavCoordinator;
@@ -111,8 +112,16 @@ public class QuizesActivity extends AppCompatActivity {
 
         ImageButton report_back = findViewById(R.id.quiz_back);
         report_back.setOnClickListener(v -> {
-            startActivity(new Intent(this, EducationActivity.class));
-            finish();
+            new AlertDialog.Builder(this)
+                    .setTitle("Quit Quiz")
+                    .setMessage("Are you sure you want to quit? Your progress will be lost.")
+                    .setPositiveButton("Quit", (dialog, which) -> {
+                        if (countDownTimer != null) countDownTimer.cancel();
+                        startActivity(new Intent(this, EducationActivity.class));
+                        finish();
+                    })
+                    .setNegativeButton("Resume", null)
+                    .show();
         });
     }
 
@@ -268,9 +277,16 @@ public class QuizesActivity extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        countDownTimer.cancel();
-        finish();
-        super.onBackPressed();
+        new AlertDialog.Builder(this)
+                .setTitle("Quit Quiz")
+                .setMessage("Are you sure you want to quit? Your progress will be lost.")
+                .setPositiveButton("Quit", (dialog, which) -> {
+                    if (countDownTimer != null) countDownTimer.cancel();
+                    finish();
+                    QuizesActivity.super.onBackPressed();
+                })
+                .setNegativeButton("Resume", null)
+                .show();
     }
 
     private void showResults() {


### PR DESCRIPTION
## What this PR does
Pressing the back button mid-quiz silently exited without any warning, causing users to lose their progress unexpectedly. This fix adds a confirmation dialog to both exit paths.

## Changes made
- Added AlertDialog confirmation to the quiz_back ImageButton handler
- Added AlertDialog confirmation to the onBackPressed() handler
- Added null check on countDownTimer.cancel() for safety
- Fixed inconsistency between the two exit paths - both now behave the same way

## Testing
- Tested on emulator - confirmation dialog appears when pressing back mid-quiz
- Resume button dismisses dialog and continues quiz as expected
- Quit button cancels timer and navigates back to Education screen