### PR TITLE
feat(community): add live character counter to new post message field

### DIFF
--- a/app/src/main/java/com/example/smishingdetectionapp/Community/CommunityNewPost.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/Community/CommunityNewPost.java
@@ -5,6 +5,9 @@ import android.os.Bundle;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageButton;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.widget.TextView;
 import android.widget.Toast;
 import android.content.SharedPreferences;
 import androidx.appcompat.app.AppCompatActivity;
@@ -25,6 +28,7 @@ public class CommunityNewPost extends AppCompatActivity {
 
     private EditText titleInput, messageInput;
     private Button sharePostBtn;
+    private TextView charCounter;
     private ImageButton backButton;
     private TabLayout tabLayout;
     private BottomNavigationView bottomNav;
@@ -36,6 +40,24 @@ public class CommunityNewPost extends AppCompatActivity {
 
         titleInput = findViewById(R.id.etPostTitle);
         messageInput = findViewById(R.id.etPostMessage);
+        charCounter = findViewById(R.id.tvCharCounter);
+
+        messageInput.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                int len = s.length();
+                charCounter.setText(len + "/500");
+                charCounter.setTextColor(len >= 500
+                        ? getResources().getColor(R.color.red, getTheme())
+                        : getResources().getColor(R.color.grey, getTheme()));
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {}
+        });
         sharePostBtn = findViewById(R.id.btnSharePost);
         backButton = findViewById(R.id.community_back);
         tabLayout = findViewById(R.id.tabLayout);

--- a/app/src/main/res/layout/activity_communitynewpost.xml
+++ b/app/src/main/res/layout/activity_communitynewpost.xml
@@ -125,6 +125,17 @@
                 android:inputType="textMultiLine"
                 android:background="@drawable/rounded_lightblue_border"
                 android:padding="12dp"
+                android:maxLength="500"
+                android:layout_marginBottom="4dp"/>
+
+            <TextView
+                android:id="@+id/tvCharCounter"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="0/500"
+                android:textSize="12sp"
+                android:textColor="@color/grey"
+                android:gravity="end"
                 android:layout_marginBottom="24dp"/>
 
             <!-- Submit Post Button -->


### PR DESCRIPTION
## What this PR does
The message field in the Create New Post screen had no character limit or counter, leaving users with no indication of how long their message could be.

## Changes made
- Added 500 character limit to the message EditText in activity_communitynewpost.xml
- Added a live "0/500" counter TextView below the message field
- Wired up a TextWatcher in CommunityNewPost.java to update the counter as the user types
- Counter turns red when the 500 character limit is reached

## Testing
- Tested on emulator - counter updates live while typing
- Counter correctly turns red at 500 characters
- Input is capped at 500 characters as expected