### PR TITLE
fix: show notification permission banner only on first launch

### DIFF
--- a/app/src/main/java/com/example/smishingdetectionapp/MainActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/MainActivity.java
@@ -2,6 +2,7 @@ package com.example.smishingdetectionapp;
 
 import android.annotation.SuppressLint;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -46,7 +47,10 @@ public class MainActivity extends SharedActivity {
                 R.id.nav_home, R.id.nav_report, R.id.nav_news, R.id.nav_settings
         ).build();
 
-        if (!areNotificationsEnabled()) {
+        SharedPreferences prefs = getSharedPreferences("app_prefs", MODE_PRIVATE);
+        boolean bannerShown = prefs.getBoolean("notification_banner_shown", false);
+        if (!bannerShown && !areNotificationsEnabled()) {
+            prefs.edit().putBoolean("notification_banner_shown", true).apply();
             showNotificationPermissionDialog();
         }
 


### PR DESCRIPTION
Fixed bug where the enable notifications permission banner was appearing every time the user navigated back to the Home screen.

Changes made:
- Added SharedPreferences check in MainActivity.java to track if the banner has been shown before
- Banner now only appears on the very first app launch
- Subsequent returns to the Home screen no longer trigger the banner