### PR TITLE
feat(quiz): add red colour warning to timer when 5 seconds or less remain

### DIFF
--- a/app/src/main/java/com/example/smishingdetectionapp/QuizesActivity.java
+++ b/app/src/main/java/com/example/smishingdetectionapp/QuizesActivity.java
@@ -1,6 +1,7 @@
 package com.example.smishingdetectionapp;
 
 import android.content.Intent;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.os.CountDownTimer;
 import android.widget.Button;
@@ -146,12 +147,19 @@ public class QuizesActivity extends AppCompatActivity {
         countDownTimer = new CountDownTimer(QUESTION_TIME, 1000) {
             @Override
             public void onTick(long millisUntilFinished) {
-                timerTextView.setText("Time: " + millisUntilFinished / 1000 + " sec");
+                long secondsLeft = millisUntilFinished / 1000;
+                timerTextView.setText("Time: " + secondsLeft + " sec");
+                if (secondsLeft <= 5) {
+                    timerTextView.setTextColor(getResources().getColor(R.color.red, getTheme()));
+                } else {
+                    timerTextView.setTextColor(Color.parseColor("#333333"));
+                }
             }
 
             @Override
             public void onFinish() {
                 timerTextView.setText("Time's up!");
+                timerTextView.setTextColor(Color.parseColor("#333333"));
                 // Record full time (15 sec) if timer runs out.
                 timeSpentPerQuestion.add((int) (QUESTION_TIME / 1000));
                 // Auto-move to next question; leave answer as -1 (unanswered).


### PR DESCRIPTION
## What this PR does
The quiz timer showed remaining time but gave no visual warning when time was running low. Users had no urgent cue to answer quickly before time ran out.

## Changes made
- Timer text turns red when 5 seconds or less remain
- Timer resets to original colour (#333333) when a new question loads
- Colour also resets in onFinish so it does not carry over

## Testing
- Tested on emulator - timer text turns red at 5 seconds remaining
- Colour resets correctly when time runs out